### PR TITLE
feat: publish pre-built Docker images to ghcr.io

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,65 @@
+name: Build and Publish Docker Images
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta-backend
+        with:
+          images: ${{ env.IMAGE_PREFIX }}-backend
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/metadata-action@v5
+        id: meta-frontend
+        with:
+          images: ${{ env.IMAGE_PREFIX }}-frontend
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.backend
+          target: prod
+          push: true
+          tags: ${{ steps.meta-backend.outputs.tags }}
+          labels: ${{ steps.meta-backend.outputs.labels }}
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.frontend
+          target: prod
+          push: true
+          tags: ${{ steps.meta-frontend.outputs.tags }}
+          labels: ${{ steps.meta-frontend.outputs.labels }}

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -27,11 +27,10 @@ ENV TSC_COMPILE_ON_ERROR=false
 ENV DISABLE_ESLINT_PLUGIN=true
 
 ARG PUBLIC_URL
-ARG REACT_APP_API_URL
 ARG REACT_APP_WS_URL
 
 RUN PUBLIC_URL=$PUBLIC_URL \
-    REACT_APP_API_URL=$REACT_APP_API_URL \
+    REACT_APP_API_URL=__REACT_APP_API_URL_PLACEHOLDER__ \
     REACT_APP_WS_URL=$REACT_APP_WS_URL \
     npm run build
 
@@ -47,6 +46,10 @@ COPY --from=build /app/build ./build
 
 RUN echo '{ "rewrites": [{ "source": "**", "destination": "/index.html" }] }' > serve.json
 
+COPY scripts/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 EXPOSE 3001
 
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["serve", "-s", "build", "-l", "3001", "--config", "/app/serve.json"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,5 @@
 # docker-compose.prod.yml
-# Production environment with optional Traefik proxy support
+# Production environment with pre-built images from ghcr.io
 #
 # Direct access:
 #   docker compose -f docker-compose.prod.yml up -d
@@ -11,12 +11,7 @@
 
 services:
   frontend:
-    build:
-      context: .
-      dockerfile: Dockerfile.frontend
-      args:
-        PUBLIC_URL: ${PUBLIC_URL:-/}
-        REACT_APP_API_URL: ${REACT_APP_API_URL:-http://localhost:3002}
+    image: ghcr.io/ttpears/snap-dns-frontend:${IMAGE_TAG:-latest}
     container_name: snap-dns-frontend-prod
     ports:
       - "${FRONTEND_PORT:-3001}:3001"
@@ -28,6 +23,7 @@ services:
       # - proxy
     environment:
       - NODE_ENV=production
+      - REACT_APP_API_URL=${REACT_APP_API_URL:-http://localhost:3002}
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3001').then(r=>{process.exit(r.ok?0:1)}).catch(()=>process.exit(1))"]
       interval: 30s
@@ -44,9 +40,7 @@ services:
     restart: unless-stopped
 
   backend:
-    build:
-      context: .
-      dockerfile: Dockerfile.backend
+    image: ghcr.io/ttpears/snap-dns-backend:${IMAGE_TAG:-latest}
     container_name: snap-dns-backend-prod
     ports:
       - "${BACKEND_PORT:-3002}:3002"

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Replace API URL placeholder with runtime environment variable
+if [ -n "$REACT_APP_API_URL" ]; then
+  find /app/build -name '*.js' -exec sed -i "s|__REACT_APP_API_URL_PLACEHOLDER__|$REACT_APP_API_URL|g" {} +
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to build and push frontend/backend images to `ghcr.io` on push to main
- Frontend entrypoint script injects `REACT_APP_API_URL` at runtime, supporting any reverse proxy setup (NPM, Traefik, etc.)
- Production compose updated to pull pre-built images instead of building on the target host

## Test plan
- [ ] Verify GitHub Actions workflow builds both images successfully
- [ ] Pull images on target host and confirm containers start
- [ ] Confirm `REACT_APP_API_URL` is correctly injected at runtime