### PR TITLE
Fix UX: hide SSO when disabled, add change password, improve messages

### DIFF
--- a/backend/src/routes/ssoConfigRoutes.ts
+++ b/backend/src/routes/ssoConfigRoutes.ts
@@ -9,6 +9,20 @@ import { auditService, AuditEventType } from '../services/auditService';
 const router = Router();
 
 /**
+ * GET /api/sso-config/status
+ * Public endpoint - returns whether SSO is enabled (no auth required)
+ */
+router.get('/status', async (req: Request, res: Response) => {
+  try {
+    const enabled = await ssoConfigService.isEnabled();
+    res.json({ ssoEnabled: enabled });
+  } catch (error) {
+    console.error('Get SSO status error:', error);
+    res.json({ ssoEnabled: false });
+  }
+});
+
+/**
  * GET /api/sso-config
  * Get SSO configuration (admin only)
  */

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,13 +1,18 @@
 // src/components/Layout.tsx
-import React from 'react';
-import { Box, Typography, IconButton, Divider, Button, Menu, MenuItem, Chip } from '@mui/material';
+import React, { useState } from 'react';
+import {
+  Box, Typography, IconButton, Divider, Button, Menu, MenuItem, Chip,
+  Dialog, DialogTitle, DialogContent, DialogActions, TextField, Alert,
+  CircularProgress,
+} from '@mui/material';
 import { useLocation } from 'react-router-dom';
-import { Brightness4, Brightness7, AccountCircle, Logout } from '@mui/icons-material';
+import { Brightness4, Brightness7, AccountCircle, Logout, Lock } from '@mui/icons-material';
 import Navigation from './Navigation';
 import PendingChangesDrawer from './PendingChangesDrawer';
 import { useConfig } from '../context/ConfigContext';
 import { usePendingChanges } from '../context/PendingChangesContext';
 import { useAuth } from '../context/AuthContext';
+import { authService } from '../services/authService';
 import Footer from './Footer';
 import { useTheme } from '../context/ThemeContext';
 
@@ -17,6 +22,13 @@ function Layout({ children }: { children: React.ReactNode }) {
   const { config } = useConfig();
   const { user, logout } = useAuth();
   const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
+  const [passwordDialogOpen, setPasswordDialogOpen] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [passwordSuccess, setPasswordSuccess] = useState<string | null>(null);
+  const [changingPassword, setChangingPassword] = useState(false);
   const {
     pendingChanges,
     showPendingDrawer,
@@ -36,6 +48,45 @@ function Layout({ children }: { children: React.ReactNode }) {
   const handleLogout = async () => {
     handleUserMenuClose();
     await logout();
+  };
+
+  const handleOpenPasswordDialog = () => {
+    handleUserMenuClose();
+    setCurrentPassword('');
+    setNewPassword('');
+    setConfirmPassword('');
+    setPasswordError(null);
+    setPasswordSuccess(null);
+    setPasswordDialogOpen(true);
+  };
+
+  const handleChangePassword = async () => {
+    setPasswordError(null);
+    setPasswordSuccess(null);
+
+    if (newPassword.length < 8) {
+      setPasswordError('New password must be at least 8 characters');
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setPasswordError('New passwords do not match');
+      return;
+    }
+
+    setChangingPassword(true);
+    try {
+      const result = await authService.changePassword(currentPassword, newPassword);
+      if (result.success) {
+        setPasswordSuccess('Password changed successfully');
+        setTimeout(() => setPasswordDialogOpen(false), 1500);
+      } else {
+        setPasswordError(result.error || 'Failed to change password');
+      }
+    } catch {
+      setPasswordError('Failed to connect to server');
+    } finally {
+      setChangingPassword(false);
+    }
   };
 
   const getPageTitle = () => {
@@ -122,6 +173,10 @@ function Layout({ children }: { children: React.ReactNode }) {
                     </Typography>
                   </MenuItem>
                   <Divider />
+                  <MenuItem onClick={handleOpenPasswordDialog}>
+                    <Lock fontSize="small" sx={{ mr: 1 }} />
+                    Change Password
+                  </MenuItem>
                   <MenuItem onClick={handleLogout}>
                     <Logout fontSize="small" sx={{ mr: 1 }} />
                     Logout
@@ -134,6 +189,64 @@ function Layout({ children }: { children: React.ReactNode }) {
         {children}
       </Box>
       <Footer />
+
+      {/* Change Password Dialog */}
+      <Dialog open={passwordDialogOpen} onClose={() => setPasswordDialogOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Change Password</DialogTitle>
+        <DialogContent>
+          {passwordError && (
+            <Alert severity="error" sx={{ mb: 2, mt: 1 }}>{passwordError}</Alert>
+          )}
+          {passwordSuccess && (
+            <Alert severity="success" sx={{ mb: 2, mt: 1 }}>{passwordSuccess}</Alert>
+          )}
+          <TextField
+            margin="dense"
+            label="Current Password"
+            type="password"
+            fullWidth
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+            autoComplete="current-password"
+            disabled={changingPassword}
+          />
+          <TextField
+            margin="dense"
+            label="New Password"
+            type="password"
+            fullWidth
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            autoComplete="new-password"
+            helperText="Must be at least 8 characters"
+            disabled={changingPassword}
+          />
+          <TextField
+            margin="dense"
+            label="Confirm New Password"
+            type="password"
+            fullWidth
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            autoComplete="new-password"
+            disabled={changingPassword}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPasswordDialogOpen(false)} disabled={changingPassword}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleChangePassword}
+            variant="contained"
+            disabled={changingPassword || !currentPassword || !newPassword || !confirmPassword}
+            startIcon={changingPassword ? <CircularProgress size={16} /> : undefined}
+          >
+            Change Password
+          </Button>
+        </DialogActions>
+      </Dialog>
+
       <PendingChangesDrawer
         open={showPendingDrawer}
         onClose={() => setShowPendingDrawer(false)}

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -23,6 +23,24 @@ export default function Login() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [ssoEnabled, setSsoEnabled] = useState(false);
+  const [ssoChecked, setSsoChecked] = useState(false);
+
+  // Check if SSO is enabled
+  useEffect(() => {
+    const checkSSOStatus = async () => {
+      try {
+        const response = await fetch(`${API_URL}/api/sso-config/status`);
+        const data = await response.json();
+        setSsoEnabled(data.ssoEnabled === true);
+      } catch {
+        setSsoEnabled(false);
+      } finally {
+        setSsoChecked(true);
+      }
+    };
+    checkSSOStatus();
+  }, []);
 
   // Check for SSO errors in URL params
   useEffect(() => {
@@ -30,7 +48,6 @@ export default function Login() {
     const errorParam = params.get('error');
     if (errorParam) {
       const errorMessages: Record<string, string> = {
-        sso_disabled: 'SSO is not enabled on this server',
         sso_init_failed: 'Failed to initiate SSO login',
         invalid_state: 'Invalid authentication state (possible CSRF attack)',
         no_code: 'No authorization code received from identity provider',
@@ -91,19 +108,23 @@ export default function Login() {
             </Alert>
           )}
 
-          {/* SSO Login Button */}
-          <Button
-            fullWidth
-            variant="contained"
-            size="large"
-            startIcon={<MicrosoftIcon />}
-            onClick={handleSSOLogin}
-            sx={{ mb: 2 }}
-          >
-            Sign in with Microsoft
-          </Button>
+          {/* SSO Login Button - only shown when SSO is enabled */}
+          {ssoChecked && ssoEnabled && (
+            <>
+              <Button
+                fullWidth
+                variant="contained"
+                size="large"
+                startIcon={<MicrosoftIcon />}
+                onClick={handleSSOLogin}
+                sx={{ mb: 2 }}
+              >
+                Sign in with Microsoft
+              </Button>
 
-          <Divider sx={{ my: 2 }}>OR</Divider>
+              <Divider sx={{ my: 2 }}>OR</Divider>
+            </>
+          )}
 
           <Box component="form" onSubmit={handleSubmit} noValidate>
             <TextField
@@ -142,9 +163,11 @@ export default function Login() {
               {isLoading ? <CircularProgress size={24} /> : 'Sign In'}
             </Button>
 
-            <Typography variant="caption" color="text.secondary" sx={{ mt: 2, display: 'block', textAlign: 'center' }}>
-              Local authentication for fallback access
-            </Typography>
+            {ssoEnabled && (
+              <Typography variant="caption" color="text.secondary" sx={{ mt: 2, display: 'block', textAlign: 'center' }}>
+                Local authentication for fallback access
+              </Typography>
+            )}
           </Box>
         </Paper>
       </Box>

--- a/src/components/ZoneEditor.tsx
+++ b/src/components/ZoneEditor.tsx
@@ -525,9 +525,17 @@ function ZoneEditor() {
         </Tooltip>
       </Box>
 
-      {!selectedZone || !selectedKey ? (
+      {!selectedZone && !selectedKey ? (
         <Alert severity="info" sx={{ mb: 2 }}>
-          No TSIG key found for this zone. Please configure a key first.
+          Select a zone and TSIG key from the sidebar to get started.
+        </Alert>
+      ) : !selectedZone ? (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Select a zone from the sidebar to view and manage records.
+        </Alert>
+      ) : !selectedKey ? (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          No TSIG key is associated with this zone. Configure a key in Settings to manage records.
         </Alert>
       ) : error ? (
         <Alert severity="error" sx={{ mb: 2 }}>


### PR DESCRIPTION
## Summary
- **SSO button hidden when disabled**: Added public `/api/sso-config/status` endpoint. Login page now checks SSO status and only shows the Microsoft sign-in button when SSO is enabled, eliminating confusing "SSO is not enabled" errors.
- **Change Password UI**: Added a Change Password dialog accessible from the user dropdown menu, wiring up the existing `authService.changePassword()` backend endpoint that previously had no UI.
- **Improved ZoneEditor messages**: Replaced the generic "No TSIG key found" alert with context-specific guidance depending on whether a zone, key, or both are missing.

## Test plan
- [ ] With SSO disabled: verify login page shows only the local auth form (no Microsoft button, no "OR" divider, no "fallback" caption)
- [ ] With SSO enabled: verify login page shows Microsoft button, divider, and fallback caption
- [ ] Click user menu > Change Password, verify dialog opens with current/new/confirm fields
- [ ] Test password change with wrong current password (should show error)
- [ ] Test password change with mismatched new passwords (client-side validation)
- [ ] Test successful password change
- [ ] Navigate to Zone Editor with no zone selected — verify "Select a zone and TSIG key" message
- [ ] Select a zone with no associated key — verify "No TSIG key is associated" message