### PR TITLE
Add versioning strategy, bump script, and OCI labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,32 @@ docker-compose -f docker-compose.prod.yml up -d
 # - docker-compose.prod.yml - Production with optional Traefik proxy support
 ```
 
+## Versioning & Releases
+
+The project uses semantic versioning. Both `package.json` (root) and `backend/package.json` must stay in sync.
+
+### Version Bump Workflow
+```bash
+# Bump and tag (updates both package.json files, commits, creates git tag)
+./scripts/bump-version.sh patch   # 2.1.0 → 2.1.1
+./scripts/bump-version.sh minor   # 2.1.0 → 2.2.0
+./scripts/bump-version.sh major   # 2.1.0 → 3.0.0
+./scripts/bump-version.sh 2.5.0   # explicit version
+
+# Push the commit and tag to trigger the Docker publish workflow
+git push origin HEAD && git push origin v<version>
+```
+
+### Docker Image Tags
+
+The GitHub Actions workflow (`.github/workflows/docker-publish.yml`) publishes to GHCR on:
+- **Push to `main`**: tags images with `main`, `latest`, and short SHA
+- **Push of `v*` tag**: tags images with the semver version (e.g., `2.1.0`)
+
+Images: `ghcr.io/ttpears/snap-dns-frontend` and `ghcr.io/ttpears/snap-dns-backend`
+
+Production compose (`docker-compose.prod.yml`) uses `${IMAGE_TAG:-latest}` — set `IMAGE_TAG=2.1.0` to pin a specific release.
+
 ## Architecture
 
 ### Frontend Structure

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -35,6 +35,10 @@ RUN npm run build
 # Clean image — only compiled JS, production deps, and DNS tools
 FROM node:20-slim AS prod
 
+LABEL org.opencontainers.image.source="https://github.com/ttpears/snap-dns"
+LABEL org.opencontainers.image.description="Snap DNS - Backend API"
+LABEL org.opencontainers.image.licenses="MIT"
+
 WORKDIR /app
 
 RUN apt-get update && \

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -38,6 +38,10 @@ RUN PUBLIC_URL=$PUBLIC_URL \
 # Clean image — no source, no node_modules
 FROM node:20-slim AS prod
 
+LABEL org.opencontainers.image.source="https://github.com/ttpears/snap-dns"
+LABEL org.opencontainers.image.description="Snap DNS - Frontend UI"
+LABEL org.opencontainers.image.licenses="MIT"
+
 WORKDIR /app
 
 RUN npm install -g serve@latest

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# scripts/bump-version.sh
+# Bumps the version in both package.json files, commits, and creates a git tag.
+#
+# Usage:
+#   ./scripts/bump-version.sh <major|minor|patch>
+#   ./scripts/bump-version.sh 2.3.0          # explicit version
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+die() { echo "Error: $*" >&2; exit 1; }
+
+# --- Resolve new version ---------------------------------------------------
+CURRENT=$(node -p "require('$REPO_ROOT/package.json').version")
+
+case "${1:-}" in
+  major|minor|patch)
+    IFS='.' read -r MAJ MIN PAT <<< "$CURRENT"
+    case "$1" in
+      major) NEW="$((MAJ + 1)).0.0" ;;
+      minor) NEW="$MAJ.$((MIN + 1)).0" ;;
+      patch) NEW="$MAJ.$MIN.$((PAT + 1))" ;;
+    esac
+    ;;
+  [0-9]*)
+    NEW="$1"
+    # Basic semver check
+    [[ "$NEW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "Invalid semver: $NEW"
+    ;;
+  *)
+    echo "Usage: $0 <major|minor|patch|X.Y.Z>"
+    echo "  Current version: $CURRENT"
+    exit 1
+    ;;
+esac
+
+[[ "$NEW" == "$CURRENT" ]] && die "Version $NEW is already current"
+
+echo "Bumping version: $CURRENT -> $NEW"
+
+# --- Update package.json files ---------------------------------------------
+cd "$REPO_ROOT"
+
+# Use npm version --no-git-tag-version so we control the commit ourselves
+npm version "$NEW" --no-git-tag-version --allow-same-version
+cd backend && npm version "$NEW" --no-git-tag-version --allow-same-version
+cd "$REPO_ROOT"
+
+# --- Commit and tag ---------------------------------------------------------
+git add package.json backend/package.json
+git commit -m "chore: bump version to $NEW"
+git tag -a "v$NEW" -m "Release v$NEW"
+
+echo ""
+echo "Version bumped to $NEW"
+echo "  - package.json updated"
+echo "  - backend/package.json updated"
+echo "  - Commit created"
+echo "  - Tag v$NEW created"
+echo ""
+echo "Next steps:"
+echo "  git push origin HEAD && git push origin v$NEW"


### PR DESCRIPTION
## Summary
- **Version bump script** (`scripts/bump-version.sh`): Accepts `major`/`minor`/`patch` or explicit version, updates both `package.json` files in sync, commits, and creates a `v*` git tag
- **OCI labels** on both Dockerfile prod stages for source, description, and license metadata
- **CLAUDE.md** updated with Versioning & Releases section documenting the bump workflow and Docker image tagging strategy

## Test plan
- [ ] Run `./scripts/bump-version.sh` with no args -- should show usage and current version
- [ ] Verify `./scripts/bump-version.sh patch` updates both package.json files, creates commit and tag
- [ ] Verify pushing a `v*` tag triggers docker-publish workflow with semver image tags