### PR TITLE
fix: add trust proxy for secure cookies behind reverse proxy

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -30,6 +30,7 @@ dotenv.config({ path: path.resolve(__dirname, `../.env.${NODE_ENV}`) }); // Load
 
 // Create express app
 const app: Express = express();
+app.set('trust proxy', 1);
 
 // Session store configuration
 const SessionFileStore = FileStore(session);


### PR DESCRIPTION
## Summary
- Adds `app.set('trust proxy', 1)` so Express honours `X-Forwarded-Proto` from reverse proxies
- Without this, secure session cookies are never set when behind NPM/Traefik/nginx, breaking authentication

## Test plan
- [ ] Deploy behind NPM, verify login sets session cookie
- [ ] Verify curl can authenticate and use the API