### PR TITLE
fix: require current password when admin changes own password

### DIFF
--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -601,7 +601,7 @@ router.patch('/users/:userId/zones', requireAuth, requireRole(UserRole.ADMIN), a
 router.patch('/users/:userId/password', requireAuth, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
   try {
     const { userId } = req.params;
-    const { newPassword } = req.body;
+    const { newPassword, currentPassword } = req.body;
 
     if (!newPassword || newPassword.length < 8) {
       return res.status(400).json({
@@ -619,6 +619,26 @@ router.patch('/users/:userId/password', requireAuth, requireRole(UserRole.ADMIN)
         error: 'User not found',
         code: 'USER_NOT_FOUND'
       });
+    }
+
+    // Require current password when admin is changing their own password
+    if (userId === req.session.userId) {
+      if (!currentPassword) {
+        return res.status(400).json({
+          success: false,
+          error: 'Current password is required when changing your own password',
+          code: 'CURRENT_PASSWORD_REQUIRED'
+        });
+      }
+
+      const authenticated = await userService.authenticate(user.username, currentPassword);
+      if (!authenticated) {
+        return res.status(401).json({
+          success: false,
+          error: 'Current password is incorrect',
+          code: 'INVALID_PASSWORD'
+        });
+      }
     }
 
     await userService.updatePassword(userId, newPassword);

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -35,6 +35,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import LockResetIcon from '@mui/icons-material/LockReset';
 import { userService, UserResponse, UserCreateData } from '../services/userService';
 import { tsigKeyService, TSIGKey } from '../services/tsigKeyService';
+import { useAuth } from '../context/AuthContext';
 
 const ROLES = [
   { value: 'admin', label: 'Admin', description: 'Full access to all features' },
@@ -43,6 +44,7 @@ const ROLES = [
 ];
 
 function UserManagement() {
+  const { user: currentUser } = useAuth();
   const [users, setUsers] = useState<UserResponse[]>([]);
   const [keys, setKeys] = useState<TSIGKey[]>([]);
   const [loading, setLoading] = useState(true);
@@ -67,6 +69,7 @@ function UserManagement() {
   });
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
+  const [currentPassword, setCurrentPassword] = useState('');
 
   useEffect(() => {
     loadData();
@@ -166,7 +169,14 @@ function UserManagement() {
   const handleResetPassword = async () => {
     if (!selectedUser) return;
 
+    const isOwnPassword = selectedUser.id === currentUser?.id;
+
     try {
+      if (isOwnPassword && !currentPassword) {
+        setError('Current password is required when changing your own password');
+        return;
+      }
+
       if (!newPassword || newPassword.length < 8) {
         setError('Password must be at least 8 characters');
         return;
@@ -177,12 +187,17 @@ function UserManagement() {
         return;
       }
 
-      await userService.resetPassword(selectedUser.id, newPassword);
+      await userService.resetPassword(
+        selectedUser.id,
+        newPassword,
+        isOwnPassword ? currentPassword : undefined
+      );
       setSuccess('Password reset successfully');
       setPasswordDialogOpen(false);
       setSelectedUser(null);
       setNewPassword('');
       setConfirmPassword('');
+      setCurrentPassword('');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to reset password');
     }
@@ -215,6 +230,7 @@ function UserManagement() {
     setSelectedUser(user);
     setNewPassword('');
     setConfirmPassword('');
+    setCurrentPassword('');
     setPasswordDialogOpen(true);
   };
 
@@ -597,8 +613,20 @@ function UserManagement() {
           <Typography variant="body2" gutterBottom>
             Reset password for <strong>{selectedUser?.username}</strong>
           </Typography>
+          {selectedUser?.id === currentUser?.id && (
+            <TextField
+              autoFocus
+              margin="dense"
+              label="Current Password"
+              type="password"
+              fullWidth
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              required
+            />
+          )}
           <TextField
-            autoFocus
+            autoFocus={selectedUser?.id !== currentUser?.id}
             margin="dense"
             label="New Password"
             type="password"

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -132,12 +132,17 @@ class UserService {
   /**
    * Reset user password (admin only)
    */
-  async resetPassword(userId: string, newPassword: string): Promise<void> {
+  async resetPassword(userId: string, newPassword: string, currentPassword?: string): Promise<void> {
+    const body: Record<string, string> = { newPassword };
+    if (currentPassword) {
+      body.currentPassword = currentPassword;
+    }
+
     const response = await fetch(`${API_URL}/api/auth/users/${userId}/password`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ newPassword }),
+      body: JSON.stringify(body),
     });
 
     const data = await response.json();


### PR DESCRIPTION
## Summary
- Admin password reset endpoint now requires `currentPassword` re-verification when an admin targets their own account
- Frontend reset dialog renders a Current Password field when the target user is the logged-in admin
- Other users' passwords can still be reset by admins without verification (admins don't know other users' current passwords)

## Why
A hijacked admin session could previously be used to change the legitimate admin's password without knowing the old one, locking them out. Re-authentication closes that window for self-targeted resets.

## Test plan
- [ ] As admin, open user management → reset own password without entering current password → expect 400 error
- [ ] As admin, reset own password with wrong current password → expect 401
- [ ] As admin, reset own password with correct current password → expect success and ability to log in with new password
- [ ] As admin, reset another user's password (no current password field shown) → expect success