### PR TITLE
Apply pending changes / restore atomically via one nsupdate transaction

### DIFF
--- a/backend/src/middleware/validation.ts
+++ b/backend/src/middleware/validation.ts
@@ -64,6 +64,21 @@ export const UpdateRecordRequestSchema = z.object({
 });
 
 /**
+ * Atomic batch of changes for one zone (used by the pending-changes apply /
+ * restore flow).
+ */
+export const BatchChangeSchema = z.object({
+  op: z.enum(['add', 'delete', 'update']),
+  record: DNSRecordSchema.optional(),
+  oldRecord: DNSRecordSchema.optional(),
+  newRecord: DNSRecordSchema.optional()
+});
+
+export const BatchRequestSchema = z.object({
+  changes: z.array(BatchChangeSchema).min(1, 'At least one change is required').max(1000, 'Too many changes in one batch')
+});
+
+/**
  * TSIG Key schemas
  */
 export const TSIGKeyCreateSchema = z.object({
@@ -239,6 +254,7 @@ export const validateDNSRecord = validateRequest(DNSRecordSchema);
 export const validateAddRecord = validateRequest(AddRecordRequestSchema);
 export const validateDeleteRecord = validateRequest(DeleteRecordRequestSchema);
 export const validateUpdateRecord = validateRequest(UpdateRecordRequestSchema);
+export const validateBatch = validateRequest(BatchRequestSchema);
 export const validateTSIGKeyCreate = validateRequest(TSIGKeyCreateSchema);
 export const validateTSIGKeyUpdate = validateRequest(TSIGKeyUpdateSchema);
 export const validateLogin = validateRequest(LoginRequestSchema);

--- a/backend/src/routes/zoneRoutes.ts
+++ b/backend/src/routes/zoneRoutes.ts
@@ -9,7 +9,8 @@ import { userService } from '../services/userService';
 import { validationService } from '../services/validationService';
 import { auditService } from '../services/auditService';
 import { dnsQueryLimiter, dnsModifyLimiter } from '../middleware/rateLimiter';
-import { validateAddRecord, validateDeleteRecord, validateUpdateRecord } from '../middleware/validation';
+import { validateAddRecord, validateDeleteRecord, validateUpdateRecord, validateBatch } from '../middleware/validation';
+import { BatchChange } from '../services/dnsService';
 
 const router = Router();
 
@@ -487,4 +488,103 @@ router.patch(
   }
 });
 
-export default router; 
+// Apply a batch of changes to a zone atomically (single nsupdate transaction).
+// Used by the pending-changes apply / restore flow so a multi-record change is
+// all-or-nothing rather than partially applied on failure.
+router.post(
+  '/:zone/records/batch',
+  dnsModifyLimiter,
+  requireAuth,
+  requireWriteAccess,
+  validateBatch,
+  async (req: Request, res: Response) => {
+  try {
+    const authReq = req as AuthenticatedRequest;
+    const user = authReq.user!;
+    const { zone } = req.params;
+    const { changes } = req.body as { changes: BatchChange[] };
+
+    if (!await checkZoneAccess(user, zone)) {
+      return res.status(403).json({
+        success: false,
+        code: ErrorCodes.PERMISSION_DENIED,
+        error: 'Access denied to this zone',
+        details: { zone }
+      });
+    }
+
+    // Validate every record in the batch on the backend (don't trust frontend).
+    const allWarnings: string[] = [];
+    for (const change of changes) {
+      const records = change.op === 'update'
+        ? [change.oldRecord, change.newRecord]
+        : [change.record];
+      for (const record of records) {
+        if (!record) {
+          return res.status(400).json({
+            success: false,
+            code: ErrorCodes.VALIDATION_ERROR,
+            error: `Missing record for "${change.op}" change`,
+            details: { change }
+          });
+        }
+        const validation = validationService.validateRecord(record, zone);
+        if (!validation.isValid) {
+          return res.status(400).json({
+            success: false,
+            code: ErrorCodes.VALIDATION_ERROR,
+            error: 'Invalid DNS record in batch',
+            details: { errors: validation.errors, record }
+          });
+        }
+        allWarnings.push(...validation.warnings);
+      }
+    }
+
+    // For admins, get all key IDs; otherwise use the user's allowed keys
+    let allowedKeyIds = user.allowedKeyIds;
+    if (user.role === 'admin') {
+      const allKeys = await tsigKeyService.listKeys();
+      allowedKeyIds = allKeys.map(k => k.id);
+    }
+
+    const tsigKey = await tsigKeyService.getKeyForZone(zone, user.userId, allowedKeyIds);
+    if (!tsigKey) {
+      return res.status(403).json({
+        success: false,
+        code: ErrorCodes.MISSING_CONFIG,
+        error: 'No TSIG key found for this zone',
+        details: { zone }
+      });
+    }
+
+    const keyConfig: ZoneConfig = {
+      server: tsigKey.server,
+      keyName: tsigKey.keyName,
+      keyValue: tsigKey.keyValue,
+      algorithm: tsigKey.algorithm,
+      id: tsigKey.id
+    };
+
+    const result = await dnsService.applyBatch(zone, changes, keyConfig);
+
+    // Audit each applied operation (the transaction succeeded as a whole).
+    for (const change of changes) {
+      const record = change.op === 'update' ? { old: change.oldRecord, new: change.newRecord } : change.record;
+      await auditService.logDNSOperation(change.op, zone, record, user.userId, user.username, true);
+    }
+
+    res.json({ ...result, warnings: allWarnings });
+  } catch (err: unknown) {
+    const error = err as DNSError;
+    console.error('Failed to apply batch:', error);
+    res.status(500).json({
+      success: false,
+      code: ErrorCodes.SERVER_ERROR,
+      error: 'Failed to apply changes',
+      details: process.env.NODE_ENV === 'development' ? error.message : undefined
+    });
+  }
+});
+
+export default router;

--- a/backend/src/services/__tests__/dnsService.batch.test.ts
+++ b/backend/src/services/__tests__/dnsService.batch.test.ts
@@ -1,0 +1,88 @@
+// backend/src/services/__tests__/dnsService.batch.test.ts
+// Atomic batch apply: all of a zone's changes go into one nsupdate transaction.
+import { execFile } from 'child_process';
+import { writeFile } from 'fs/promises';
+import { dnsService, BatchChange } from '../dnsService';
+import { ZoneConfig, DNSRecord } from '../../types/dns';
+
+jest.mock('child_process', () => ({ execFile: jest.fn() }));
+jest.mock('fs/promises', () => ({
+  writeFile: jest.fn(async () => undefined),
+  unlink: jest.fn(async () => undefined),
+  mkdir: jest.fn(async () => undefined),
+}));
+
+const mockedExecFile = execFile as unknown as jest.Mock;
+const mockedWriteFile = writeFile as unknown as jest.Mock;
+
+const keyConfig: ZoneConfig = {
+  server: 'ns1.example.com',
+  keyName: 'update-key',
+  keyValue: 'dGVzdHNlY3JldA==',
+  algorithm: 'hmac-sha256',
+  id: 'key_1',
+};
+
+beforeEach(() => {
+  mockedExecFile.mockReset();
+  mockedWriteFile.mockClear();
+  mockedExecFile.mockImplementation((_cmd: string, ...rest: unknown[]) => {
+    const cb = rest[rest.length - 1] as (err: unknown, out: { stdout: string; stderr: string }) => void;
+    cb(null, { stdout: '', stderr: '' });
+  });
+});
+
+const batchFileContent = (): string => {
+  const call = mockedWriteFile.mock.calls.find(([p]) => typeof p === 'string' && p.includes('batch-'));
+  return call ? (call[1] as string) : '';
+};
+
+const rec = (over: Partial<DNSRecord>): DNSRecord =>
+  ({ name: 'x.example.com', type: 'A', value: '1.2.3.4', ttl: 300, class: 'IN', ...over });
+
+describe('applyBatch', () => {
+  it('emits add/delete/update in one transaction with a single send', async () => {
+    const changes: BatchChange[] = [
+      { op: 'add', record: rec({ name: 'a.example.com', value: '1.1.1.1' }) },
+      { op: 'delete', record: rec({ name: 'b.example.com', value: '2.2.2.2' }) },
+      { op: 'update', oldRecord: rec({ name: 'c.example.com', value: '3.3.3.3' }), newRecord: rec({ name: 'c.example.com', value: '4.4.4.4' }) },
+    ];
+    await dnsService.applyBatch('example.com', changes, keyConfig);
+
+    const c = batchFileContent();
+    expect(c).toContain('update add a.example.com 300 IN A 1.1.1.1');
+    expect(c).toContain('update delete b.example.com A 2.2.2.2');
+    expect(c).toContain('prereq yxrrset c.example.com A 3.3.3.3');
+    expect(c).toContain('update delete c.example.com A 3.3.3.3');
+    expect(c).toContain('update add c.example.com 300 IN A 4.4.4.4');
+    // one server/zone header and exactly one send → atomic
+    expect(c.match(/^send$/gm)?.length).toBe(1);
+    expect(c.startsWith('server ns1.example.com\nzone example.com\n')).toBe(true);
+    // one nsupdate invocation, no dig
+    const cmds = mockedExecFile.mock.calls.map(x => x[0]);
+    expect(cmds).toEqual(['nsupdate']);
+  });
+
+  it('quotes TXT values in a batched update', async () => {
+    const changes: BatchChange[] = [
+      { op: 'update', oldRecord: rec({ name: 't.example.com', type: 'TXT', value: 'v=spf1 -all' }), newRecord: rec({ name: 't.example.com', type: 'TXT', value: 'v=spf1 ~all' }) },
+    ];
+    await dnsService.applyBatch('example.com', changes, keyConfig);
+    const c = batchFileContent();
+    expect(c).toContain('prereq yxrrset t.example.com TXT "v=spf1 -all"');
+    expect(c).toContain('update add t.example.com 300 IN TXT "v=spf1 ~all"');
+  });
+
+  it('rejects the whole batch if any record carries an injection payload (before running)', async () => {
+    const changes: BatchChange[] = [
+      { op: 'add', record: rec({ name: 'ok.example.com' }) },
+      { op: 'add', record: rec({ name: 'evil\nupdate delete victim.example.com' }) },
+    ];
+    await expect(dnsService.applyBatch('example.com', changes, keyConfig)).rejects.toThrow(/Invalid record name/);
+    expect(mockedExecFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty batch', async () => {
+    await expect(dnsService.applyBatch('example.com', [], keyConfig)).rejects.toThrow(/no changes/i);
+  });
+});

--- a/backend/src/services/dnsService.ts
+++ b/backend/src/services/dnsService.ts
@@ -8,6 +8,15 @@ import { config } from '../config';
 import { assertNoControlChars, isValidDnsName, isValidZoneName } from './dnsSafety';
 import { parseTxtRdata, quoteTxtValue } from './dnsPresentation';
 
+/** A single change in an atomic batch. `add`/`delete` use `record`; `update`
+ *  uses `oldRecord` + `newRecord`. */
+export interface BatchChange {
+  op: 'add' | 'delete' | 'update';
+  record?: DNSRecord;
+  oldRecord?: DNSRecord;
+  newRecord?: DNSRecord;
+}
+
 // execFile (not exec) runs the binary directly with an argv array — no shell is
 // spawned, so zone/server/key arguments cannot be interpreted as shell syntax.
 const execFileAsync = promisify(execFile);
@@ -606,6 +615,100 @@ class DNSService {
       throw new Error(`Failed to update record: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }
+
+  /**
+   * Build the nsupdate command lines for a single change (no server/zone/send).
+   * Add/delete/update produce the same directives the single-record methods do,
+   * so a batch is byte-for-byte consistent with applying each change alone.
+   */
+  private buildChangeLines(change: BatchChange): string[] {
+    switch (change.op) {
+      case 'add': {
+        const r = change.record!;
+        this.assertSafeRecord(r);
+        return [`update add ${r.name} ${r.ttl} ${r.class || 'IN'} ${r.type} ${this.formatRdata(r)}`];
+      }
+      case 'delete': {
+        const r = change.record!;
+        this.assertSafeRecord(r);
+        const hasData = r.value !== undefined && r.value !== null && r.value !== '';
+        if (!hasData || r.type === 'SOA') {
+          return [`update delete ${r.name} ${r.type}`];
+        }
+        return [`update delete ${r.name} ${r.type} ${this.formatRdata(r)}`];
+      }
+      case 'update': {
+        const oldR = change.oldRecord!;
+        const newR = change.newRecord!;
+        this.assertSafeRecord(oldR);
+        this.assertSafeRecord(newR);
+
+        if (newR.type === 'SOA') {
+          const oldSOA = oldR.value as any;
+          const newSOA = newR.value as any;
+          if (typeof newSOA?.serial === 'number' && typeof oldSOA?.serial === 'number' && newSOA.serial <= oldSOA.serial) {
+            newSOA.serial = oldSOA.serial + 1;
+          }
+          return [
+            `update delete ${oldR.name} ${oldR.type}`,
+            `update add ${newR.name} ${newR.ttl} ${newR.class || 'IN'} ${newR.type} ${this.formatSOA(newSOA)}`,
+          ];
+        }
+
+        const hasOldData = oldR.value !== undefined && oldR.value !== null && oldR.value !== '';
+        const lines: string[] = [];
+        if (hasOldData) {
+          const oldRdata = this.formatRdata(oldR);
+          // Fail the whole transaction if the record being replaced isn't present
+          // as given (RFC 2136 §2.4.1), rather than silently adding a duplicate.
+          lines.push(`prereq yxrrset ${oldR.name} ${oldR.type} ${oldRdata}`);
+          lines.push(`update delete ${oldR.name} ${oldR.type} ${oldRdata}`);
+        } else {
+          lines.push(`prereq yxrrset ${oldR.name} ${oldR.type}`);
+          lines.push(`update delete ${oldR.name} ${oldR.type}`);
+        }
+        lines.push(`update add ${newR.name} ${newR.ttl} ${newR.class || 'IN'} ${newR.type} ${this.formatRdata(newR)}`);
+        return lines;
+      }
+      default:
+        throw new Error(`Unknown batch operation: ${(change as { op?: string }).op}`);
+    }
+  }
+
+  /**
+   * Apply a set of changes to one zone as a single atomic nsupdate transaction
+   * (one `send`). RFC 2136 makes the whole set all-or-nothing: if any operation
+   * or prerequisite fails, nothing is applied — no half-updated zone. Used by
+   * the pending-changes apply / restore flow.
+   */
+  async applyBatch(zone: string, changes: BatchChange[], keyConfig: ZoneConfig): Promise<ZoneOperationResult> {
+    if (!isValidZoneName(zone)) {
+      throw new Error(`Invalid zone name: ${zone}`);
+    }
+    this.validateKeyConfig(keyConfig);
+    if (!Array.isArray(changes) || changes.length === 0) {
+      throw new Error('Batch contains no changes');
+    }
+
+    await this.initialize();
+    const updateFile = join(this.getTempDir(), `batch-${Date.now()}-${Math.random()}.txt`);
+
+    const lines: string[] = [`server ${keyConfig.server}`, `zone ${zone}`];
+    for (const change of changes) {
+      lines.push(...this.buildChangeLines(change));
+    }
+    lines.push('send'); // single send → atomic
+
+    try {
+      await writeFile(updateFile, lines.join('\n'));
+      await this.runNsupdate(updateFile, keyConfig);
+      return { success: true, message: `Applied ${changes.length} change${changes.length !== 1 ? 's' : ''}` };
+    } catch (error) {
+      throw new Error(`Failed to apply changes: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    } finally {
+      await unlink(updateFile).catch(() => undefined);
+    }
+  }
 }
 
-export const dnsService = new DNSService(); 
+export const dnsService = new DNSService();

--- a/src/components/PendingChangesDrawer.tsx
+++ b/src/components/PendingChangesDrawer.tsx
@@ -27,7 +27,7 @@ import {
   KeyboardArrowDown as ExpandMoreIcon,
   KeyboardArrowUp as ExpandLessIcon
 } from '@mui/icons-material';
-import { dnsService } from '../services/dnsService';
+import { dnsService, type BatchChange } from '../services/dnsService';
 import { notificationService } from '../services/notificationService';
 import { usePendingChanges } from '../context/PendingChangesContext';
 import { backupService } from '../services/backupService';
@@ -146,58 +146,26 @@ function PendingChangesDrawer({
             // Don't fail the entire operation if snapshot creation fails
           }
 
-          // Apply changes in order
-          for (const change of changes) {
-            try {
-              switch ((change as any).type) {
-                case 'ADD': {
-                  const addResult = await dnsService.addRecord(zone, change.record! as any);
-                  if (addResult?.warnings?.length) allWarnings.push(...addResult.warnings);
-                  allSuccessfulChanges.push({
-                    ...change,
-                    type: 'ADD'
-                  });
-                  break;
-                }
-                case 'RESTORE': {
-                  // For restore, we need to ensure the record is properly formatted
-                  const recordToRestore = {
-                    ...change.record!,
-                    name: change.record!.name,
-                    type: change.record!.type,
-                    value: change.record!.value,
-                    ttl: change.record!.ttl || 3600  // Ensure TTL exists
-                  };
-                  const restoreResult = await dnsService.addRecord(zone, recordToRestore as any);
-                  if (restoreResult?.warnings?.length) allWarnings.push(...restoreResult.warnings);
-                  allSuccessfulChanges.push({
-                    ...change,
-                    type: 'ADD',
-                    record: recordToRestore as any
-                  });
-                  break;
-                }
-                case 'DELETE': {
-                  const deleteResult = await dnsService.deleteRecord(zone, change.record! as any);
-                  if (deleteResult?.warnings?.length) allWarnings.push(...deleteResult.warnings);
-                  allSuccessfulChanges.push(change);
-                  break;
-                }
-                case 'MODIFY': {
-                  // Use atomic update for modifications (especially important for SOA)
-                  const updateResult = await dnsService.updateRecord(zone, change.originalRecord! as any, change.newRecord! as any);
-                  if (updateResult?.warnings?.length) allWarnings.push(...updateResult.warnings);
-                  allSuccessfulChanges.push(change);
-                  break;
-                }
-                default:
-                  console.warn(`Unknown change type: ${change.type}`);
-              }
-            } catch (changeError) {
-              console.error(`Failed to apply change:`, changeError);
-              throw new Error(`Failed to apply change: ${(changeError as Error).message}`);
+          // Apply all of this zone's changes as one atomic transaction, so a
+          // failure can't leave the zone half-updated.
+          const batchChanges: BatchChange[] = changes.map((change) => {
+            switch ((change as any).type) {
+              case 'ADD':
+                return { op: 'add', record: change.record! as any };
+              case 'RESTORE':
+                return { op: 'add', record: { ...(change.record! as any), ttl: change.record!.ttl || 3600 } };
+              case 'DELETE':
+                return { op: 'delete', record: change.record! as any };
+              case 'MODIFY':
+                return { op: 'update', oldRecord: change.originalRecord! as any, newRecord: change.newRecord! as any };
+              default:
+                throw new Error(`Unknown change type: ${(change as any).type}`);
             }
-          }
+          });
+
+          const batchResult = await dnsService.applyBatch(zone, batchChanges);
+          if (batchResult?.warnings?.length) allWarnings.push(...batchResult.warnings);
+          allSuccessfulChanges.push(...changes);
 
           // Add zone to affected zones
           if (!affectedZones.includes(zone)) {

--- a/src/services/__tests__/dnsService.applyBatch.test.ts
+++ b/src/services/__tests__/dnsService.applyBatch.test.ts
@@ -1,0 +1,45 @@
+// src/services/__tests__/dnsService.applyBatch.test.ts
+import { dnsService, type BatchChange, type DNSRecord } from '../dnsService';
+
+describe('dnsService.applyBatch (frontend client)', () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    (global as any).fetch = fetchMock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, warnings: ['w1'] }),
+    });
+  });
+
+  it('POSTs all changes to the batch endpoint and returns warnings', async () => {
+    const changes: BatchChange[] = [
+      { op: 'add', record: { name: 'a', type: 'A', value: '1.1.1.1', ttl: 300 } as DNSRecord },
+      { op: 'delete', record: { name: 'b', type: 'A', value: '2.2.2.2', ttl: 300 } as DNSRecord },
+      {
+        op: 'update',
+        oldRecord: { name: 'c', type: 'A', value: '3.3.3.3', ttl: 300 } as DNSRecord,
+        newRecord: { name: 'c', type: 'A', value: '4.4.4.4', ttl: 300 } as DNSRecord,
+      },
+    ];
+
+    const result = await dnsService.applyBatch('example.com', changes);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/zones/example.com/records/batch');
+    expect(opts.method).toBe('POST');
+    const body = JSON.parse(opts.body);
+    expect(body.changes).toHaveLength(3);
+    expect(body.changes[0].op).toBe('add');
+    expect(body.changes[2].op).toBe('update');
+    expect(body.changes[2].oldRecord.value).toBe('3.3.3.3');
+    expect(result.warnings).toEqual(['w1']);
+  });
+
+  it('rejects an empty change set without calling the API', async () => {
+    await expect(dnsService.applyBatch('example.com', [])).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/backupService.ts
+++ b/src/services/backupService.ts
@@ -1,7 +1,7 @@
 // src/services/backupService.ts
 import { notificationService } from './notificationService';
-import { dnsService, type DNSRecord } from './dnsService';
-import type { Config, KeyConfig } from '../config';
+import type { DNSRecord } from './dnsService';
+import type { Config } from '../config';
 
 import { getApiUrl } from '../utils/apiUrl';
 const API_URL = getApiUrl();
@@ -142,23 +142,6 @@ export class BackupService {
         throw new Error(`Failed to create backup: ${error.message}`);
       }
       throw new Error('Failed to create backup: Unknown error');
-    }
-  }
-
-  async restoreRecords(backup: DNSBackup, config: Config, selectedRecords?: DNSRecord[]): Promise<void> {
-    try {
-      const recordsToRestore = selectedRecords || backup.records;
-
-      // Keys are now handled server-side, no need for keyConfig
-      for (const record of recordsToRestore) {
-        await dnsService.addRecord(backup.zone, record);
-      }
-    } catch (error: unknown) {
-      console.error('Failed to restore records:', error);
-      if (error instanceof Error) {
-        throw new Error(`Failed to restore records: ${error.message}`);
-      }
-      throw new Error('Failed to restore records: Unknown error');
     }
   }
 

--- a/src/services/dnsService.ts
+++ b/src/services/dnsService.ts
@@ -30,6 +30,15 @@ interface DNSRecord {
 
 export type { DNSRecord, SRVRecord, MXRecord };
 
+/** A single change in an atomic batch. `add`/`delete` use `record`; `update`
+ *  uses `oldRecord` + `newRecord`. */
+export interface BatchChange {
+  op: 'add' | 'delete' | 'update';
+  record?: DNSRecord;
+  oldRecord?: DNSRecord;
+  newRecord?: DNSRecord;
+}
+
 // Add error types
 export class DNSError extends Error {
   code?: string;
@@ -252,6 +261,56 @@ class DNSService {
         const errorData = await response.json().catch(() => ({ error: response.statusText }));
         throw new DNSError(
           errorData.error || `Failed to update record: ${response.statusText}`,
+          errorData.code,
+          errorData.details
+        );
+      }
+
+      const data = await response.json().catch(() => ({}));
+      return { warnings: data.warnings };
+    } catch (error) {
+      if (error instanceof DNSError) {
+        throw error;
+      }
+      throw new DNSError(
+        'Failed to communicate with DNS server',
+        'SERVER_ERROR',
+        error instanceof Error ? error.message : undefined
+      );
+    }
+  }
+
+  /**
+   * Apply a set of changes to one zone atomically (single backend transaction).
+   * Each record is formatted the same way the single-record calls format it.
+   */
+  async applyBatch(zone: string, changes: BatchChange[]): Promise<{ warnings?: string[] }> {
+    try {
+      if (!zone || !changes || changes.length === 0) {
+        throw new Error('Zone and at least one change are required');
+      }
+
+      const prepared = changes.map((c) =>
+        c.op === 'update'
+          ? {
+              op: c.op,
+              oldRecord: this.prepareRecordForRequest(c.oldRecord!),
+              newRecord: this.prepareRecordForRequest(c.newRecord!),
+            }
+          : { op: c.op, record: this.prepareRecordForRequest(c.record!) }
+      );
+
+      const response = await fetch(`${this.baseUrl}/api/zones/${encodeURIComponent(zone)}/records/batch`, {
+        method: 'POST',
+        headers: this.createHeaders(),
+        credentials: 'include',
+        body: JSON.stringify({ changes: prepared }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ error: response.statusText }));
+        throw new DNSError(
+          errorData.error || `Failed to apply changes: ${response.statusText}`,
           errorData.code,
           errorData.details
         );


### PR DESCRIPTION
Makes applying pending changes (and snapshot restore, which is diff-based and flows through the same path) atomic per zone, replacing the per-record apply loop that could leave a zone half-updated on a mid-loop failure.

## Problem
`PendingChangesDrawer.handleApplyChanges` applied each change with a separate HTTP call in a `for` loop — if change 4 of 7 failed, changes 1–3 were already live and the zone was left in a partial state. This affected every bulk apply, including restore. (`backupService.restoreRecords`, which the audit flagged, was actually dead code with the same additive-loop shape.)

## Fix
- **Backend `dnsService.applyBatch`** builds one nsupdate command file (`server`, `zone`, every change's directives, a single `send`) and runs `nsupdate` once. RFC 2136 makes the whole set all-or-nothing. `buildChangeLines` emits exactly the directives the single-record methods produce (add; delete; update = `prereq yxrrset` + delete + add; SOA serial bump), and every record is run through `assertSafeRecord` + `validationService` first.
- **New `POST /api/zones/:zone/records/batch`** (auth + write access + rate limit + zod), validates each record server-side and audits each op.
- **Frontend** `dnsService.applyBatch` client; `handleApplyChanges` applies one batch per zone instead of N per-record calls; the dead `restoreRecords` is removed.

## Behavior change
Apply is now **all-or-nothing per zone**: a failure (or an update `prereq` mismatch on a drifted record) applies nothing and reports the error, instead of partially applying. The pre-apply auto-snapshot is unchanged.

## Verification
Backend 85 + frontend 127 tests green (new backend batch-transaction tests + frontend client test), typecheck + lint clean, and a real `nsupdate` accepts the batched mixed-op transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)