### PR TITLE
G8: NS record UI support, ValidationResult.warnings, stale-doc refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,23 +235,11 @@ The following design issues should be addressed before production use:
 
 6. ~~**Duplicate Context Files**~~ — **RESOLVED**: Single `src/context/` directory, all files migrated to TypeScript.
 
-7. **Non-Atomic Update Operations** (src/services/dnsService.ts:272-287)
-   - `updateRecord()` performs DELETE then ADD
-   - If ADD fails after DELETE succeeds, record is lost
-   - **Impact**: Data loss risk during updates
-   - **Fix**: Use BIND's atomic update operations or implement rollback
+7. ~~**Non-Atomic Update Operations**~~ — **RESOLVED**: `updateRecord()` uses a single nsupdate transaction with a `prereq yxrrset` guard (RFC 2136 §2.4.1), and bulk apply/restore goes through `dnsService.applyBatch()` — one all-or-nothing transaction per zone.
 
-8. **No Backend Validation** (backend/src/routes/zoneRoutes.ts)
-   - Backend trusts frontend validation completely
-   - No validation layer in route handlers
-   - **Impact**: Malicious clients can bypass validation
-   - **Fix**: Implement server-side validation using existing validation service
+8. ~~**No Backend Validation**~~ — **RESOLVED**: route handlers validate every record server-side via `validationService.validateRecord` (add/delete/update/batch), plus Zod request schemas and the `dnsSafety` name/injection guards.
 
-9. **Incomplete IPv6 Validation** (src/services/dnsValidationService.ts:121)
-   - Regex doesn't handle compressed IPv6 notation (::)
-   - Doesn't validate IPv6 with embedded IPv4 (::ffff:192.0.2.1)
-   - **Impact**: Valid IPv6 addresses rejected, invalid ones accepted
-   - **Fix**: Use proper IPv6 parsing library
+9. ~~**Incomplete IPv6 Validation**~~ — **RESOLVED**: `isValidIPv6` (frontend `dnsValidationService.ts` and backend `validationService.ts`) accepts compressed (`::`), IPv4-mapped, and general embedded-IPv4 forms and rejects malformed input; `formatAAAARecord` delegates to it. IPv4 leading zeros are rejected.
 
 ### 🟡 Medium Priority Issues
 

--- a/src/components/AddDNSRecord.tsx
+++ b/src/components/AddDNSRecord.tsx
@@ -71,6 +71,15 @@ const RECORD_TYPES: Record<string, RecordTypeDefinition> = {
       required: true
     }]
   },
+  NS: {
+    fields: [{
+      name: 'value',
+      label: 'Nameserver',
+      helperText: 'Fully qualified domain name of the authoritative nameserver',
+      validate: (value) => value.length > 0,
+      required: true
+    }]
+  },
   MX: {
     fields: [
       {

--- a/src/services/__tests__/dnsValidationService.test.ts
+++ b/src/services/__tests__/dnsValidationService.test.ts
@@ -46,6 +46,13 @@ describe('DNSValidationService (G5 RFC edge cases)', () => {
     });
   });
 
+  describe('NS records', () => {
+    it('accepts a valid nameserver and rejects a malformed one', () => {
+      expect(validate({ type: 'NS', value: 'ns1.example.com.' }).isValid).toBe(true);
+      expect(validate({ type: 'NS', value: 'not a hostname' }).isValid).toBe(false);
+    });
+  });
+
   describe('false-accepts tightened (G7)', () => {
     it('rejects IPv4 octets with leading zeros', () => {
       expect(validate({ type: 'A', value: '192.168.001.1' }).isValid).toBe(false);

--- a/src/services/dnsValidationService.ts
+++ b/src/services/dnsValidationService.ts
@@ -48,6 +48,11 @@ class DNSValidationService {
           errors.push('Invalid CNAME target format');
         }
         break;
+      case 'NS':
+        if (!this.isValidHostname(record.value)) {
+          errors.push('Invalid NS target format');
+        }
+        break;
       case 'MX':
         if (!this.isValidMX(record.value)) {
           errors.push('Invalid MX record format (should be: priority hostname)');

--- a/src/types/dns.ts
+++ b/src/types/dns.ts
@@ -43,6 +43,9 @@ export interface PendingChange {
 export interface ValidationResult {
   isValid: boolean;
   errors: string[];
+  // Non-blocking advisories (e.g. SPF/DKIM/CAA warnings) the UI surfaces
+  // alongside errors; the validation service always returns this array.
+  warnings?: string[];
 }
 
 // DNS operation result


### PR DESCRIPTION
The final, low-ROI items closing the DNS-compliance backlog.

- **NS records were uncreatable in the UI** — NS was in the `RecordType` enum, the formatter, and backend validation, but missing from `AddDNSRecord`'s record-type picker. Added the picker entry plus frontend NS-target validation (`isValidHostname`), matching CNAME.
- **`ValidationResult` was missing `warnings`** — the validation service returns it and the UI reads it, but the type omitted it. Added.
- **Refreshed stale `CLAUDE.md` findings** — marked issues #7 (non-atomic updates), #8 (no backend validation), and #9 (incomplete IPv6) RESOLVED; all three are false after the compliance work.

Frontend 128 tests green, typecheck + lint clean. Backend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)