### PR TITLE
Guard SOA deletion in batch apply (review follow-up to #19)

### DIFF
--- a/backend/src/routes/zoneRoutes.ts
+++ b/backend/src/routes/zoneRoutes.ts
@@ -568,10 +568,16 @@ router.post(
 
     const result = await dnsService.applyBatch(zone, changes, keyConfig);
 
-    // Audit each applied operation (the transaction succeeded as a whole).
-    for (const change of changes) {
-      const record = change.op === 'update' ? { old: change.oldRecord, new: change.newRecord } : change.record;
-      await auditService.logDNSOperation(change.op, zone, record, user.userId, user.username, true);
+    // The transaction already committed to DNS. Audit-logging is best-effort:
+    // a logging failure must not be reported to the client as if the DNS change
+    // failed (which would prompt a confusing re-apply).
+    try {
+      for (const change of changes) {
+        const record = change.op === 'update' ? { old: change.oldRecord, new: change.newRecord } : change.record;
+        await auditService.logDNSOperation(change.op, zone, record, user.userId, user.username, true);
+      }
+    } catch (auditErr) {
+      console.error('Batch applied but audit logging failed:', auditErr);
     }
 
     res.json({ ...result, warnings: allWarnings });

--- a/backend/src/services/__tests__/dnsService.batch.test.ts
+++ b/backend/src/services/__tests__/dnsService.batch.test.ts
@@ -85,4 +85,29 @@ describe('applyBatch', () => {
   it('rejects an empty batch', async () => {
     await expect(dnsService.applyBatch('example.com', [], keyConfig)).rejects.toThrow(/no changes/i);
   });
+
+  it('refuses to delete an SOA record in a batch (never runs anything)', async () => {
+    const changes: BatchChange[] = [
+      { op: 'delete', record: rec({ name: 'example.com', type: 'SOA', value: 'ns admin 1 2 3 4 5' }) },
+    ];
+    await expect(dnsService.applyBatch('example.com', changes, keyConfig)).rejects.toThrow(/SOA records cannot be deleted/);
+    expect(mockedExecFile).not.toHaveBeenCalled();
+  });
+
+  it('propagates an nsupdate failure so nothing is reported as applied', async () => {
+    mockedExecFile.mockImplementation((_cmd: string, ...rest: unknown[]) => {
+      const cb = rest[rest.length - 1] as (err: unknown, out: { stdout: string; stderr: string }) => void;
+      cb(new Error('update failed: REFUSED'), { stdout: '', stderr: 'update failed: REFUSED' });
+    });
+    const changes: BatchChange[] = [{ op: 'add', record: rec({ name: 'a.example.com' }) }];
+    await expect(dnsService.applyBatch('example.com', changes, keyConfig)).rejects.toThrow(/Failed to apply changes/);
+  });
+});
+
+describe('deleteRecord SOA guard (single-record path)', () => {
+  it('refuses to delete an SOA record', async () => {
+    const soa = rec({ name: 'example.com', type: 'SOA', value: 'ns admin 1 2 3 4 5' });
+    await expect(dnsService.deleteRecord('example.com', soa, keyConfig)).rejects.toThrow(/SOA records cannot be deleted/);
+    expect(mockedExecFile).not.toHaveBeenCalled();
+  });
 });

--- a/backend/src/services/dnsService.ts
+++ b/backend/src/services/dnsService.ts
@@ -631,8 +631,15 @@ class DNSService {
       case 'delete': {
         const r = change.record!;
         this.assertSafeRecord(r);
+        // Every zone must keep exactly one SOA; deleting it is never valid. The
+        // single-record deleteRecord() enforces this at its call site, so the
+        // batch builder must too (a "select all → delete" would otherwise wipe
+        // the apex SOA in one atomic transaction).
+        if (r.type === 'SOA') {
+          throw new Error('SOA records cannot be deleted. Every zone must have exactly one SOA record. Use the edit function to modify SOA fields.');
+        }
         const hasData = r.value !== undefined && r.value !== null && r.value !== '';
-        if (!hasData || r.type === 'SOA') {
+        if (!hasData) {
           return [`update delete ${r.name} ${r.type}`];
         }
         return [`update delete ${r.name} ${r.type} ${this.formatRdata(r)}`];

--- a/src/components/ZoneEditor.tsx
+++ b/src/components/ZoneEditor.tsx
@@ -256,7 +256,11 @@ function ZoneEditor() {
 
   const handleDeleteSelected = async () => {
     try {
-      selectedRecords.forEach(record => {
+      // SOA records cannot be deleted (every zone must keep exactly one), so
+      // skip them rather than queue a delete that would fail the whole batch.
+      const deletable = selectedRecords.filter(record => record.type !== 'SOA');
+
+      deletable.forEach(record => {
         const change = {
           id: Date.now() + Math.random(),
           type: 'DELETE' as const,
@@ -267,7 +271,9 @@ function ZoneEditor() {
         addPendingChange(change);
       });
 
-      setShowPendingDrawer(true);
+      if (deletable.length > 0) {
+        setShowPendingDrawer(true);
+      }
       setSelectedRecords([]);
       setEditDialogOpen(false);
       setEditingRecord(null);


### PR DESCRIPTION
Follow-up to the atomic batch-apply change (#19), from an independent code review.

## Critical: batch delete could wipe a zone's SOA
When the delete-command logic was refactored out of `deleteRecord()` (which rejects SOA deletion at its call site) into the shared `buildChangeLines`, the guard wasn't carried along — `buildChangeLines`'s `delete` case treated `type === 'SOA'` only as "delete the whole RRset."

This is reachable from the UI: `ZoneEditor` "select all" selects every record including SOA (the row checkbox has no SOA exclusion), and "Delete Selected" queues a DELETE for each. Post-#19 that flows into `applyBatch`, which would build `update delete <apex> SOA` into the transaction and commit it — wiping the zone's SOA in one atomic, "successful" batch.

**Fix:** `buildChangeLines` rejects an SOA delete (mirroring `deleteRecord`), and the bulk-delete UI filters SOA out of the selection so the remaining records still delete cleanly.

## Also (lower severity, from the same review)
Batch-route audit logging is now best-effort: a logging failure after the transaction already committed no longer returns a 500 as if the DNS change failed (which would invite a confusing re-apply).

## Tests
New regression tests: SOA delete rejected in a batch and in the single-record path, and `applyBatch` propagates an nsupdate failure. Backend 88 + frontend 127 green, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)