### PR TITLE
Manage additional record types (DS/TLSA/DNSKEY/NAPTR/SVCB/HTTPS/DNAME/…) as presentation-format values

### DIFF
--- a/backend/src/middleware/validation.ts
+++ b/backend/src/middleware/validation.ts
@@ -8,7 +8,10 @@ import { z, ZodError } from 'zod';
  * DNS Record Type enum
  */
 const RecordTypeSchema = z.enum([
-  'A', 'AAAA', 'CNAME', 'MX', 'TXT', 'SRV', 'NS', 'PTR', 'CAA', 'SSHFP', 'SOA'
+  'A', 'AAAA', 'CNAME', 'MX', 'TXT', 'SRV', 'NS', 'PTR', 'CAA', 'SSHFP', 'SOA',
+  // Managed as opaque presentation-format values (RFC 3597 style).
+  'DS', 'DNSKEY', 'CDS', 'CDNSKEY', 'TLSA', 'SMIMEA', 'NAPTR', 'SVCB', 'HTTPS',
+  'DNAME', 'LOC', 'CERT', 'URI', 'KX'
 ]);
 
 /**

--- a/backend/src/services/__tests__/dnsService.batch.test.ts
+++ b/backend/src/services/__tests__/dnsService.batch.test.ts
@@ -63,6 +63,17 @@ describe('applyBatch', () => {
     expect(cmds).toEqual(['nsupdate']);
   });
 
+  it('writes generic presentation-format types (TLSA/DS) verbatim', async () => {
+    const changes: BatchChange[] = [
+      { op: 'add', record: rec({ name: '_443._tcp.example.com', type: 'TLSA', value: '3 0 1 ABCDEF0123456789' }) },
+      { op: 'add', record: rec({ name: 'example.com', type: 'DS', value: '12345 8 2 49FD46E6' }) },
+    ];
+    await dnsService.applyBatch('example.com', changes, keyConfig);
+    const c = batchFileContent();
+    expect(c).toContain('update add _443._tcp.example.com 300 IN TLSA 3 0 1 ABCDEF0123456789');
+    expect(c).toContain('update add example.com 300 IN DS 12345 8 2 49FD46E6');
+  });
+
   it('quotes TXT values in a batched update', async () => {
     const changes: BatchChange[] = [
       { op: 'update', oldRecord: rec({ name: 't.example.com', type: 'TXT', value: 'v=spf1 -all' }), newRecord: rec({ name: 't.example.com', type: 'TXT', value: 'v=spf1 ~all' }) },

--- a/backend/src/services/__tests__/validationService.test.ts
+++ b/backend/src/services/__tests__/validationService.test.ts
@@ -149,6 +149,23 @@ describe('validationService.validateRecord', () => {
     });
   });
 
+  describe('additional record types (generic presentation format)', () => {
+    it('accepts a non-empty presentation value for a generic type (TLSA/DS)', () => {
+      expect(validate({ type: 'TLSA', value: '3 0 1 abcdef0123456789' }).isValid).toBe(true);
+      expect(validate({ type: 'DS', value: '12345 8 2 49FD46E6C4B45C55D4AC' }).isValid).toBe(true);
+      expect(validate({ type: 'SVCB', value: '1 . alpn=h2,h3' }).isValid).toBe(true);
+    });
+
+    it('still requires a value for a generic type', () => {
+      expect(validate({ type: 'TLSA', value: '' }).isValid).toBe(false);
+    });
+
+    it('validates DNAME as a domain-name target', () => {
+      expect(validate({ type: 'DNAME', value: 'target.example.net.' }).isValid).toBe(true);
+      expect(validate({ type: 'DNAME', value: 'not a hostname' }).isValid).toBe(false);
+    });
+  });
+
   describe('RFC edge cases (G5)', () => {
     it('accepts TTL 0 (RFC 2181 §8)', () => {
       const res = validationService.validateRecord({ name: 'host', type: 'A', value: '1.2.3.4', ttl: 0 }, 'example.com');

--- a/backend/src/services/__tests__/validationService.test.ts
+++ b/backend/src/services/__tests__/validationService.test.ts
@@ -164,6 +164,20 @@ describe('validationService.validateRecord', () => {
       expect(validate({ type: 'DNAME', value: 'target.example.net.' }).isValid).toBe(true);
       expect(validate({ type: 'DNAME', value: 'not a hostname' }).isValid).toBe(false);
     });
+
+    it('structurally validates DS/CDS (numeric fields + hex digest)', () => {
+      expect(validate({ type: 'DS', value: '12345 8 2 49FD46E6C4B4' }).isValid).toBe(true);
+      expect(validate({ type: 'DS', value: '12345 8 2 XYZnothex' }).isValid).toBe(false); // digest not hex
+      expect(validate({ type: 'DS', value: '99999999 8 2 ABCD' }).isValid).toBe(false); // key-tag > 65535
+      expect(validate({ type: 'CDS', value: '12345 8 2 ABCD' }).isValid).toBe(true);
+    });
+
+    it('structurally validates TLSA/SMIMEA (numeric fields + hex cert)', () => {
+      expect(validate({ type: 'TLSA', value: '3 0 1 ABCDEF0123' }).isValid).toBe(true);
+      expect(validate({ type: 'TLSA', value: '3 0 1 nothex!!' }).isValid).toBe(false);
+      expect(validate({ type: 'TLSA', value: '3 0' }).isValid).toBe(false); // too few fields
+      expect(validate({ type: 'SMIMEA', value: '3 0 1 ABCD' }).isValid).toBe(true);
+    });
   });
 
   describe('RFC edge cases (G5)', () => {

--- a/backend/src/services/validationService.ts
+++ b/backend/src/services/validationService.ts
@@ -84,6 +84,7 @@ class ValidationService {
       case 'CNAME':
       case 'NS':
       case 'PTR':
+      case 'DNAME':
         if (!this.isValidHostname(record.value)) {
           errors.push(`Invalid ${record.type} target format`);
         }

--- a/backend/src/services/validationService.ts
+++ b/backend/src/services/validationService.ts
@@ -150,6 +150,20 @@ class ValidationService {
         this.validateCAA(record.value, errors, warnings);
         break;
 
+      case 'DS':
+      case 'CDS':
+        if (!this.isValidDS(record.value)) {
+          errors.push(`Invalid ${record.type} record format (should be: key-tag algorithm digest-type digest-hex)`);
+        }
+        break;
+
+      case 'TLSA':
+      case 'SMIMEA':
+        if (!this.isValidTLSA(record.value)) {
+          errors.push(`Invalid ${record.type} record format (should be: usage selector matching-type certificate-hex)`);
+        }
+        break;
+
       case 'SOA':
         // SOA validation is complex, validate basic structure
         if (typeof record.value === 'object') {
@@ -245,6 +259,36 @@ class ValidationService {
     if (!/^\d+$/.test(token)) return false;
     const num = parseInt(token, 10);
     return num >= 0 && num <= 65535;
+  }
+
+  private isValidUint8(token: string): boolean {
+    if (!/^\d+$/.test(token)) return false;
+    const num = parseInt(token, 10);
+    return num >= 0 && num <= 255;
+  }
+
+  // DS/CDS: key-tag(uint16) algorithm(uint8) digest-type(uint8) digest(hex).
+  private isValidDS(value: string): boolean {
+    if (typeof value !== 'string') return false;
+    const parts = value.trim().split(/\s+/);
+    if (parts.length < 4) return false;
+    const digest = parts.slice(3).join('');
+    return this.isValidUint16(parts[0]) &&
+      this.isValidUint8(parts[1]) &&
+      this.isValidUint8(parts[2]) &&
+      /^[0-9a-fA-F]+$/.test(digest);
+  }
+
+  // TLSA/SMIMEA: usage(uint8) selector(uint8) matching-type(uint8) cert(hex).
+  private isValidTLSA(value: string): boolean {
+    if (typeof value !== 'string') return false;
+    const parts = value.trim().split(/\s+/);
+    if (parts.length < 4) return false;
+    const cert = parts.slice(3).join('');
+    return this.isValidUint8(parts[0]) &&
+      this.isValidUint8(parts[1]) &&
+      this.isValidUint8(parts[2]) &&
+      /^[0-9a-fA-F]+$/.test(cert);
   }
 
   /**

--- a/src/components/AddDNSRecord.tsx
+++ b/src/components/AddDNSRecord.tsx
@@ -208,6 +208,33 @@ const RECORD_TYPES: Record<string, RecordTypeDefinition> = {
   }
 };
 
+// Additional record types managed as a single presentation-format value. The
+// backend guards against injection and nsupdate/BIND validates the exact rdata
+// syntax on apply, so the UI keeps a light touch (one value field + a format
+// hint) rather than a bespoke editor per type.
+const GENERIC_TYPE_HINTS: Record<string, string> = {
+  DS: 'key-tag algorithm digest-type digest — e.g. 12345 8 2 49FD46E6C4B4...',
+  DNSKEY: 'flags protocol algorithm public-key (base64)',
+  CDS: 'key-tag algorithm digest-type digest',
+  CDNSKEY: 'flags protocol algorithm public-key (base64)',
+  TLSA: 'usage selector matching-type certificate-data (hex)',
+  SMIMEA: 'usage selector matching-type certificate-data (hex)',
+  NAPTR: 'order preference "flags" "service" "regexp" replacement',
+  SVCB: 'priority target [params] — e.g. 1 . alpn="h2,h3"',
+  HTTPS: 'priority target [params] — e.g. 1 . alpn="h2,h3"',
+  DNAME: 'Target domain (FQDN ending with a dot)',
+  LOC: 'geographic location — e.g. 52 22 23.000 N 4 53 32.000 E 2.00m',
+  CERT: 'type key-tag algorithm certificate (base64)',
+  URI: 'priority weight "target-uri"',
+  KX: 'preference exchanger (FQDN)',
+};
+
+for (const [type, helperText] of Object.entries(GENERIC_TYPE_HINTS)) {
+  RECORD_TYPES[type] = {
+    fields: [{ name: 'value', label: 'Value (presentation format)', helperText, required: true }],
+  };
+}
+
 const mapErrorToField = (error: string): string => {
   const lower = (error || '').toLowerCase();
   if (lower.includes('ttl')) return 'ttl';

--- a/src/components/ZoneEditor.tsx
+++ b/src/components/ZoneEditor.tsx
@@ -45,11 +45,11 @@ import RecordEditor from './RecordEditor';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { useKey } from '../context/KeyContext';
 import PendingChangesDrawer from './PendingChangesDrawer';
-import { DNSRecord } from '../types/dns';
+import { DNSRecord, RecordType } from '../types/dns';
 
-const recordTypes = [
-  'A', 'AAAA', 'CNAME', 'MX', 'TXT', 'SRV', 'NS', 'PTR', 'CAA', 'SSHFP', 'SOA'
-];
+// Sourced from the RecordType enum so the type filter stays in sync with the
+// supported types (no separate hardcoded list to drift).
+const recordTypes = Object.values(RecordType);
 
 interface MultilineRecordDialogProps {
   record: DNSRecord | null;

--- a/src/services/__tests__/dnsRecordFormatter.test.ts
+++ b/src/services/__tests__/dnsRecordFormatter.test.ts
@@ -95,6 +95,24 @@ describe('DNSRecordFormatter.qualifyName', () => {
   });
 });
 
+describe('DNSRecordFormatter generic/DNAME handling', () => {
+  const fmt = (type: string, value: string) =>
+    DNSRecordFormatter.formatRecord(
+      { name: 'x', type, value, ttl: 300 } as unknown as DNSRecord,
+      'example.com'
+    ).value;
+
+  it('adds a trailing dot to a DNAME target (name-valued)', () => {
+    expect(fmt('DNAME', 'sub.example.net')).toBe('sub.example.net.');
+  });
+
+  it('passes generic presentation-format types through unchanged', () => {
+    expect(fmt('TLSA', '3 0 1 ABCDEF0123')).toBe('3 0 1 ABCDEF0123');
+    expect(fmt('DS', '12345 8 2 49FD46E6')).toBe('12345 8 2 49FD46E6');
+    expect(fmt('SVCB', '1 . alpn=h2,h3')).toBe('1 . alpn=h2,h3');
+  });
+});
+
 describe('DNSRecordFormatter AAAA handling', () => {
   const aaaa = (value: string) =>
     DNSRecordFormatter.formatRecord(

--- a/src/services/__tests__/dnsValidationService.test.ts
+++ b/src/services/__tests__/dnsValidationService.test.ts
@@ -46,6 +46,20 @@ describe('DNSValidationService (G5 RFC edge cases)', () => {
     });
   });
 
+  describe('DS / TLSA structured validation', () => {
+    it('accepts well-formed DS and rejects a bad digest / oversized key-tag', () => {
+      expect(validate({ type: 'DS', value: '12345 8 2 49FD46E6C4B4' }).isValid).toBe(true);
+      expect(validate({ type: 'DS', value: '12345 8 2 nothex!' }).isValid).toBe(false);
+      expect(validate({ type: 'DS', value: '99999999 8 2 ABCD' }).isValid).toBe(false);
+    });
+
+    it('accepts well-formed TLSA and rejects too-few fields / non-hex cert', () => {
+      expect(validate({ type: 'TLSA', value: '3 0 1 ABCDEF' }).isValid).toBe(true);
+      expect(validate({ type: 'TLSA', value: '3 0 1 zz' }).isValid).toBe(false);
+      expect(validate({ type: 'TLSA', value: '3 0' }).isValid).toBe(false);
+    });
+  });
+
   describe('false-accepts tightened (G7)', () => {
     it('rejects IPv4 octets with leading zeros', () => {
       expect(validate({ type: 'A', value: '192.168.001.1' }).isValid).toBe(false);

--- a/src/services/dnsRecordFormatter.ts
+++ b/src/services/dnsRecordFormatter.ts
@@ -52,6 +52,7 @@ export class DNSRecordFormatter {
         return this.formatAAAARecord(value);
       case 'CNAME':
       case 'NS':
+      case 'DNAME':
         return this.formatNameRecord(value);
       case 'MX':
         return this.formatMXRecord(value);

--- a/src/services/dnsValidationService.ts
+++ b/src/services/dnsValidationService.ts
@@ -48,6 +48,11 @@ class DNSValidationService {
           errors.push('Invalid CNAME target format');
         }
         break;
+      case 'DNAME':
+        if (!this.isValidHostname(record.value)) {
+          errors.push('Invalid DNAME target format');
+        }
+        break;
       case 'MX':
         if (!this.isValidMX(record.value)) {
           errors.push('Invalid MX record format (should be: priority hostname)');

--- a/src/services/dnsValidationService.ts
+++ b/src/services/dnsValidationService.ts
@@ -78,6 +78,18 @@ class DNSValidationService {
           errors.push('Invalid SRV record format (should be: priority weight port target)');
         }
         break;
+      case 'DS':
+      case 'CDS':
+        if (!this.isValidDS(record.value)) {
+          errors.push(`Invalid ${record.type} record format (should be: key-tag algorithm digest-type digest-hex)`);
+        }
+        break;
+      case 'TLSA':
+      case 'SMIMEA':
+        if (!this.isValidTLSA(record.value)) {
+          errors.push(`Invalid ${record.type} record format (should be: usage selector matching-type certificate-hex)`);
+        }
+        break;
     }
 
     return {
@@ -179,6 +191,36 @@ class DNSValidationService {
     if (!/^\d+$/.test(token)) return false;
     const num = parseInt(token, 10);
     return num >= 0 && num <= 65535;
+  }
+
+  private static isValidUint8(token: string): boolean {
+    if (!/^\d+$/.test(token)) return false;
+    const num = parseInt(token, 10);
+    return num >= 0 && num <= 255;
+  }
+
+  // DS/CDS: key-tag(uint16) algorithm(uint8) digest-type(uint8) digest(hex).
+  private static isValidDS(value: string): boolean {
+    if (typeof value !== 'string') return false;
+    const parts = value.trim().split(/\s+/);
+    if (parts.length < 4) return false;
+    const digest = parts.slice(3).join('');
+    return this.isValidUint16(parts[0]) &&
+      this.isValidUint8(parts[1]) &&
+      this.isValidUint8(parts[2]) &&
+      /^[0-9a-fA-F]+$/.test(digest);
+  }
+
+  // TLSA/SMIMEA: usage(uint8) selector(uint8) matching-type(uint8) cert(hex).
+  private static isValidTLSA(value: string): boolean {
+    if (typeof value !== 'string') return false;
+    const parts = value.trim().split(/\s+/);
+    if (parts.length < 4) return false;
+    const cert = parts.slice(3).join('');
+    return this.isValidUint8(parts[0]) &&
+      this.isValidUint8(parts[1]) &&
+      this.isValidUint8(parts[2]) &&
+      /^[0-9a-fA-F]+$/.test(cert);
   }
 
   private static isValidMX(value: string): boolean {

--- a/src/types/dns.ts
+++ b/src/types/dns.ts
@@ -13,7 +13,23 @@ export enum RecordType {
   PTR = 'PTR',
   CAA = 'CAA',
   SOA = 'SOA',
-  SSHFP = 'SSHFP'
+  SSHFP = 'SSHFP',
+  // Additional types managed as opaque presentation-format values (RFC 3597
+  // style): DNSSEC delegation/keys, DANE, service binding, redirect, etc.
+  DS = 'DS',
+  DNSKEY = 'DNSKEY',
+  CDS = 'CDS',
+  CDNSKEY = 'CDNSKEY',
+  TLSA = 'TLSA',
+  SMIMEA = 'SMIMEA',
+  NAPTR = 'NAPTR',
+  SVCB = 'SVCB',
+  HTTPS = 'HTTPS',
+  DNAME = 'DNAME',
+  LOC = 'LOC',
+  CERT = 'CERT',
+  URI = 'URI',
+  KX = 'KX'
 }
 
 // Base DNS record interface


### PR DESCRIPTION
Closes most of the remaining "fully compliant" gap: the app could previously only manage A/AAAA/CNAME/MX/TXT/SRV/NS/PTR/CAA/SSHFP/SOA, so common DNSSEC/DANE/service-binding/redirect types couldn't be created or edited at all.

The earlier compliance work (G1–G4) already made the read/write pipeline type-generic — case-preserving AXFR parsing, `formatRdata` passthrough, and the injection guards all handle arbitrary types — so this is mostly wiring:

- **Enum + schema:** add DS, DNSKEY, CDS, CDNSKEY, TLSA, SMIMEA, NAPTR, SVCB, HTTPS, DNAME, LOC, CERT, URI, KX to the `RecordType` enum and the backend Zod `RecordTypeSchema`.
- **UI:** `AddDNSRecord` offers each with one presentation-format value field and a per-type format hint. The backend injection guards and `nsupdate`/BIND validate the actual rdata syntax on apply, so the UI stays light rather than a bespoke editor per type.
- **DNAME** is name-valued (hostname validation + trailing dot, like CNAME); the rest round-trip as opaque presentation strings.
- **Drift fix:** `ZoneEditor`'s type-filter list now derives from the `RecordType` enum instead of a separate hardcoded array.

Bespoke structured field editors and per-field validation for the complex types (NAPTR quoted fields, SVCB/HTTPS params) are intentionally deferred — this makes the types fully manageable first.

## Verification
Frontend 129 + backend 89 tests green (validation, formatter, and batch round-trip tests for the new types), typecheck + lint clean, and a real `nsupdate` accepts the generated DS/TLSA/HTTPS/DNAME presentation format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)