### PR TITLE
Show value-field format hints in the edit form (parity with add form)

### DIFF
--- a/src/components/AddDNSRecord.tsx
+++ b/src/components/AddDNSRecord.tsx
@@ -21,6 +21,7 @@ import { useConfig } from '../context/ConfigContext';
 import { DNSValidationService } from '../services/dnsValidationService';
 import { DNSRecordFormatter } from '../services/dnsRecordFormatter';
 import { detectTxtSubtype, TxtSubtype } from '../services/validators/detectTxtSubtype';
+import { VALUE_FIELD_HINTS, GENERIC_VALUE_TYPES } from '../services/recordTypeHints';
 import SpfEditor from './editors/SpfEditor';
 import DkimEditor from './editors/DkimEditor';
 import DmarcEditor from './editors/DmarcEditor';
@@ -220,27 +221,10 @@ const RECORD_TYPES: Record<string, RecordTypeDefinition> = {
 // Additional record types managed as a single presentation-format value. The
 // backend guards against injection and nsupdate/BIND validates the exact rdata
 // syntax on apply, so the UI keeps a light touch (one value field + a format
-// hint) rather than a bespoke editor per type.
-const GENERIC_TYPE_HINTS: Record<string, string> = {
-  DS: 'key-tag algorithm digest-type digest — e.g. 12345 8 2 49FD46E6C4B4...',
-  DNSKEY: 'flags protocol algorithm public-key (base64)',
-  CDS: 'key-tag algorithm digest-type digest',
-  CDNSKEY: 'flags protocol algorithm public-key (base64)',
-  TLSA: 'usage selector matching-type certificate-data (hex)',
-  SMIMEA: 'usage selector matching-type certificate-data (hex)',
-  NAPTR: 'order preference "flags" "service" "regexp" replacement',
-  SVCB: 'priority target [params] — e.g. 1 . alpn="h2,h3"',
-  HTTPS: 'priority target [params] — e.g. 1 . alpn="h2,h3"',
-  DNAME: 'Target domain (FQDN ending with a dot)',
-  LOC: 'geographic location — e.g. 52 22 23.000 N 4 53 32.000 E 2.00m',
-  CERT: 'type key-tag algorithm certificate (base64)',
-  URI: 'priority weight "target-uri"',
-  KX: 'preference exchanger (FQDN)',
-};
-
-for (const [type, helperText] of Object.entries(GENERIC_TYPE_HINTS)) {
+// hint from the shared VALUE_FIELD_HINTS) rather than a bespoke editor per type.
+for (const type of GENERIC_VALUE_TYPES) {
   RECORD_TYPES[type] = {
-    fields: [{ name: 'value', label: 'Value (presentation format)', helperText, required: true }],
+    fields: [{ name: 'value', label: 'Value (presentation format)', helperText: VALUE_FIELD_HINTS[type], required: true }],
   };
 }
 

--- a/src/components/RecordEditor.tsx
+++ b/src/components/RecordEditor.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 import { DNSValidationService } from '../services/dnsValidationService';
 import { DNSRecordFormatter } from '../services/dnsRecordFormatter';
+import { VALUE_FIELD_HINTS } from '../services/recordTypeHints';
 import { DNSRecord } from '../types/dns';
 import { detectTxtSubtype, TxtSubtype } from '../services/validators/detectTxtSubtype';
 import SpfEditor from './editors/SpfEditor';
@@ -371,12 +372,7 @@ function RecordEditor({ record, onSave, onCancel, isCopy = false }: RecordEditor
               label="Value"
               value={editedRecord.value as string}
               onChange={(e) => handleChange('value', e.target.value)}
-              helperText={
-                record.type === 'CNAME' ? 'Fully qualified domain name ending with a dot' :
-                record.type === 'A' ? 'IPv4 address (e.g., 192.168.1.1)' :
-                record.type === 'AAAA' ? 'IPv6 address' :
-                undefined
-              }
+              helperText={VALUE_FIELD_HINTS[record.type]}
             />
           </Grid>
         )}

--- a/src/components/__tests__/RecordEditor.test.tsx
+++ b/src/components/__tests__/RecordEditor.test.tsx
@@ -20,3 +20,24 @@ describe('RecordEditor CAA quoting', () => {
     );
   });
 });
+
+describe('RecordEditor value-field format hints', () => {
+  const renderType = (type: string, value: string) =>
+    render(
+      <RecordEditor
+        record={{ name: 'x', type, value, ttl: 300 } as unknown as DNSRecord}
+        onSave={jest.fn()}
+        onCancel={() => {}}
+      />
+    );
+
+  it('shows a format hint for a type that previously had none (DS)', () => {
+    renderType('DS', '12345 8 2 ABCD');
+    expect(screen.getByText(/key-tag algorithm digest-type digest/)).toBeInTheDocument();
+  });
+
+  it('shows a format hint for CAA', () => {
+    renderType('CAA', '0 issue "letsencrypt.org"');
+    expect(screen.getByText(/flags tag value/)).toBeInTheDocument();
+  });
+});

--- a/src/services/recordTypeHints.ts
+++ b/src/services/recordTypeHints.ts
@@ -1,0 +1,35 @@
+// src/services/recordTypeHints.ts
+// Format hints for a record type's single presentation-format value field,
+// shared by the add form (AddDNSRecord) and the edit form (RecordEditor) so
+// both show identical guidance. Multi-field types (MX, SRV, SOA) and TXT use
+// dedicated editors and are not listed here.
+export const VALUE_FIELD_HINTS: Record<string, string> = {
+  A: 'Enter a valid IPv4 address (e.g., 192.168.1.1)',
+  AAAA: 'Enter a valid IPv6 address',
+  CNAME: 'Fully qualified domain name (FQDN) ending with a dot',
+  NS: 'Fully qualified domain name of the authoritative nameserver',
+  PTR: 'Fully qualified domain name (FQDN) ending with a dot',
+  CAA: 'flags tag value — e.g. 0 issue "letsencrypt.org"',
+  SSHFP: 'algorithm fingerprint-type fingerprint (hex) — e.g. 4 2 abcdef...',
+  DS: 'key-tag algorithm digest-type digest — e.g. 12345 8 2 49FD46E6C4B4...',
+  DNSKEY: 'flags protocol algorithm public-key (base64)',
+  CDS: 'key-tag algorithm digest-type digest',
+  CDNSKEY: 'flags protocol algorithm public-key (base64)',
+  TLSA: 'usage selector matching-type certificate-data (hex)',
+  SMIMEA: 'usage selector matching-type certificate-data (hex)',
+  NAPTR: 'order preference "flags" "service" "regexp" replacement',
+  SVCB: 'priority target [params] — e.g. 1 . alpn="h2,h3"',
+  HTTPS: 'priority target [params] — e.g. 1 . alpn="h2,h3"',
+  DNAME: 'Target domain (FQDN ending with a dot)',
+  LOC: 'geographic location — e.g. 52 22 23.000 N 4 53 32.000 E 2.00m',
+  CERT: 'type key-tag algorithm certificate (base64)',
+  URI: 'priority weight "target-uri"',
+  KX: 'preference exchanger (FQDN)',
+};
+
+// Types managed as an opaque presentation-format value (no bespoke add-form
+// fields). Used to generate their AddDNSRecord picker entries.
+export const GENERIC_VALUE_TYPES = [
+  'DS', 'DNSKEY', 'CDS', 'CDNSKEY', 'TLSA', 'SMIMEA', 'NAPTR', 'SVCB', 'HTTPS',
+  'DNAME', 'LOC', 'CERT', 'URI', 'KX',
+] as const;


### PR DESCRIPTION
The add form shows a per-type format hint on every value field, but the edit form (`RecordEditor`) only hinted CNAME/A/AAAA. So **editing** a CAA, NS, PTR, SSHFP, or any of the newer types (DS/TLSA/DNAME/SVCB/…) gave no format guidance, even though **adding** those same types did — an inconsistency.

- Extract the hints into a shared `VALUE_FIELD_HINTS` map (`src/services/recordTypeHints.ts`) and point both `AddDNSRecord` and `RecordEditor` at it, so add and edit show identical guidance and can't drift.
- `AddDNSRecord` now also generates its generic-type picker entries from the shared list (replacing the local `GENERIC_TYPE_HINTS`).

Adds `RecordEditor` render tests asserting the hint appears for DS and CAA. Frontend 134 tests green, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)