### PR TITLE
fix(ui): make the pending-changes apply flow safe and trustworthy

### DIFF
--- a/src/components/AddDNSRecord.tsx
+++ b/src/components/AddDNSRecord.tsx
@@ -522,7 +522,7 @@ function AddDNSRecord({ zone, onSuccess, onClose }: AddDNSRecordProps) {
         return;
       }
 
-      const change: import('../types/dns').PendingChange = {
+      const change: import('../types/dns').NewPendingChange = {
         type: 'ADD',
         zone: selectedZone ?? '',
         keyId: selectedKey!.id,

--- a/src/components/PendingChangesDrawer.tsx
+++ b/src/components/PendingChangesDrawer.tsx
@@ -182,9 +182,11 @@ function PendingChangesDrawer({
         appliedChanges.push(...changes);
         appliedZones.push(zone);
 
-        // Dispatch event to notify components that changes were applied
+        // Dispatch event to notify components that changes were applied.
+        // changeIds lets listeners purge the committed changes from any
+        // local state (e.g. the undo/redo history) so they can't come back.
         window.dispatchEvent(new CustomEvent('dnsChangesApplied', {
-          detail: { zones: [zone] }
+          detail: { zones: [zone], changeIds: changes.map(c => c.id) }
         }));
       } catch (error) {
         console.error(`Failed to process changes for zone ${zone}:`, error);

--- a/src/components/PendingChangesDrawer.tsx
+++ b/src/components/PendingChangesDrawer.tsx
@@ -15,7 +15,12 @@ import {
   Stack,
   Collapse,
   Snackbar,
-  Tooltip
+  Tooltip,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions
 } from '@mui/material';
 import {
   Delete as DeleteIcon,
@@ -43,6 +48,13 @@ interface PendingChangesDrawerProps {
   clearPendingChanges: () => void;
 }
 
+// Per-zone outcome of an apply attempt, shown when a zone's batch fails
+interface ZoneApplyFailure {
+  zone: string;
+  message: string;
+  changeCount: number;
+}
+
 function PendingChangesDrawer({
   open,
   onClose,
@@ -57,7 +69,8 @@ function PendingChangesDrawer({
   const { config } = useConfig();
   const { showSuccess, showError } = useNotification();
   const [applying, setApplying] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [applyFailures, setApplyFailures] = useState<ZoneApplyFailure[]>([]);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
   const [applyWarnings, setApplyWarnings] = useState<string[]>([]);
   const [expandedItems, setExpandedItems] = useState<Record<string, boolean>>({});
@@ -106,110 +119,121 @@ function PendingChangesDrawer({
     setDraggingIndex(null);
   };
 
-  const handleApplyChanges = async () => {
-    setApplying(true);
-    setError(null);
-
-    try {
-      // Group changes by zone
-      const changesByZone = pendingChanges.reduce((acc: Record<string, PendingChange[]>, change) => {
-        if (!acc[change.zone]) {
-          acc[change.zone] = [];
-        }
-        acc[change.zone].push(change);
-        return acc;
-      }, {});
-
-      // Track all successful changes for notification
-      const allSuccessfulChanges: PendingChange[] = [];
-      const affectedZones: string[] = [];
-      const allWarnings: string[] = [];
-
-      // Apply changes zone by zone
-      for (const [zone, changes] of Object.entries(changesByZone) as [string, PendingChange[]][]) {
-        try {
-          // Create automatic snapshot before applying changes
-          try {
-            const currentRecords = await dnsService.fetchZoneRecords(zone);
-            const firstChange = changes[0];
-            const keyConfig = backendKeys.find(k => k.id === firstChange.keyId);
-
-            await backupService.createBackup(zone, currentRecords, {
-              type: 'auto',
-              description: `Automatic snapshot before applying ${changes.length} change${changes.length !== 1 ? 's' : ''}`,
-              server: keyConfig?.server || 'unknown',
-              config: config as any
-            });
-            console.log(`Auto-snapshot created for zone ${zone}`);
-          } catch (backupError) {
-            console.warn(`Failed to create auto-snapshot for zone ${zone}:`, backupError);
-            // Don't fail the entire operation if snapshot creation fails
-          }
-
-          // Apply all of this zone's changes as one atomic transaction, so a
-          // failure can't leave the zone half-updated.
-          const batchChanges: BatchChange[] = changes.map((change) => {
-            switch ((change as any).type) {
-              case 'ADD':
-                return { op: 'add', record: change.record! as any };
-              case 'RESTORE':
-                return { op: 'add', record: { ...(change.record! as any), ttl: change.record!.ttl || 3600 } };
-              case 'DELETE':
-                return { op: 'delete', record: change.record! as any };
-              case 'MODIFY':
-                return { op: 'update', oldRecord: change.originalRecord! as any, newRecord: change.newRecord! as any };
-              default:
-                throw new Error(`Unknown change type: ${(change as any).type}`);
-            }
-          });
-
-          const batchResult = await dnsService.applyBatch(zone, batchChanges);
-          if (batchResult?.warnings?.length) allWarnings.push(...batchResult.warnings);
-          allSuccessfulChanges.push(...changes);
-
-          // Add zone to affected zones
-          if (!affectedZones.includes(zone)) {
-            affectedZones.push(zone);
-          }
-
-          // Dispatch event to notify components that changes were applied
-          window.dispatchEvent(new CustomEvent('dnsChangesApplied', {
-            detail: { zones: [zone] }
-          }));
-        } catch (error) {
-          console.error(`Failed to process changes for zone ${zone}:`, error);
-          throw error;
-        }
-      }
-
-      // Send a single notification for all successful changes
-      if (allSuccessfulChanges.length > 0) {
-        try {
-          await notificationService.sendNotification('Multiple Zones', {
-            changes: allSuccessfulChanges,
-            zones: affectedZones,
-            timestamp: Date.now(),
-            totalChanges: allSuccessfulChanges.length
-          });
-        } catch (notifyError) {
-          console.warn('Failed to send notification:', notifyError);
-        }
-      }
-
-      clearPendingChanges();
-      showSuccess(`Successfully applied ${allSuccessfulChanges.length} change${allSuccessfulChanges.length !== 1 ? 's' : ''} to ${affectedZones.length} zone${affectedZones.length !== 1 ? 's' : ''}`);
-      if (allWarnings.length > 0) {
-        setApplyWarnings(allWarnings);
-      }
-      onClose();
-    } catch (error) {
-      console.error('Failed to apply changes:', error);
-      const errorMessage = `Failed to apply changes: ${(error as Error).message}`;
-      setError(errorMessage);
-      showError(errorMessage);
-    } finally {
-      setApplying(false);
+  // Group changes by zone; used by both the confirmation dialog and apply
+  const changesByZone = pendingChanges.reduce((acc: Record<string, PendingChange[]>, change) => {
+    if (!acc[change.zone]) {
+      acc[change.zone] = [];
     }
+    acc[change.zone].push(change);
+    return acc;
+  }, {});
+
+  const handleApplyChanges = async () => {
+    setConfirmOpen(false);
+    setApplying(true);
+    setApplyFailures([]);
+
+    // Each zone applies as one atomic transaction; zones are independent, so
+    // a failure in one zone doesn't stop the others. Track per-zone outcomes
+    // so applied changes can be removed from the queue even on partial failure.
+    const appliedChanges: PendingChange[] = [];
+    const appliedZones: string[] = [];
+    const failures: ZoneApplyFailure[] = [];
+    const allWarnings: string[] = [];
+
+    for (const [zone, changes] of Object.entries(changesByZone) as [string, PendingChange[]][]) {
+      try {
+        // Create automatic snapshot before applying changes
+        try {
+          const currentRecords = await dnsService.fetchZoneRecords(zone);
+          const firstChange = changes[0];
+          const keyConfig = backendKeys.find(k => k.id === firstChange.keyId);
+
+          await backupService.createBackup(zone, currentRecords, {
+            type: 'auto',
+            description: `Automatic snapshot before applying ${changes.length} change${changes.length !== 1 ? 's' : ''}`,
+            server: keyConfig?.server || 'unknown',
+            config: config as any
+          });
+        } catch (backupError) {
+          console.warn(`Failed to create auto-snapshot for zone ${zone}:`, backupError);
+          // Don't fail the entire operation if snapshot creation fails
+        }
+
+        // Apply all of this zone's changes as one atomic transaction, so a
+        // failure can't leave the zone half-updated.
+        const batchChanges: BatchChange[] = changes.map((change) => {
+          switch (change.type) {
+            case 'ADD':
+              return { op: 'add', record: change.record! as any };
+            case 'RESTORE':
+              return { op: 'add', record: { ...(change.record! as any), ttl: change.record!.ttl || 3600 } };
+            case 'DELETE':
+              return { op: 'delete', record: change.record! as any };
+            case 'MODIFY':
+              return { op: 'update', oldRecord: change.originalRecord! as any, newRecord: change.newRecord! as any };
+            default:
+              throw new Error(`Unknown change type: ${(change as any).type}`);
+          }
+        });
+
+        const batchResult = await dnsService.applyBatch(zone, batchChanges);
+        if (batchResult?.warnings?.length) allWarnings.push(...batchResult.warnings);
+        appliedChanges.push(...changes);
+        appliedZones.push(zone);
+
+        // Dispatch event to notify components that changes were applied
+        window.dispatchEvent(new CustomEvent('dnsChangesApplied', {
+          detail: { zones: [zone] }
+        }));
+      } catch (error) {
+        console.error(`Failed to process changes for zone ${zone}:`, error);
+        failures.push({
+          zone,
+          message: (error as Error).message,
+          changeCount: changes.length
+        });
+      }
+    }
+
+    // Send a single notification for all successful changes
+    if (appliedChanges.length > 0) {
+      try {
+        await notificationService.sendNotification('Multiple Zones', {
+          changes: appliedChanges,
+          zones: appliedZones,
+          timestamp: Date.now(),
+          totalChanges: appliedChanges.length
+        });
+      } catch (notifyError) {
+        console.warn('Failed to send notification:', notifyError);
+      }
+    }
+
+    // Remove applied changes from the queue even when other zones failed, so
+    // a re-apply can never double-apply committed changes.
+    if (appliedChanges.length > 0) {
+      const appliedIds = new Set(appliedChanges.map(c => c.id));
+      setPendingChanges(prev => prev.filter(c => !appliedIds.has(c.id)));
+    }
+
+    if (allWarnings.length > 0) {
+      setApplyWarnings(allWarnings);
+    }
+
+    if (failures.length === 0) {
+      showSuccess(`Successfully applied ${appliedChanges.length} change${appliedChanges.length !== 1 ? 's' : ''} to ${appliedZones.length} zone${appliedZones.length !== 1 ? 's' : ''}`);
+      setShowPendingDrawer(false);
+      onClose();
+    } else {
+      if (appliedChanges.length > 0) {
+        showSuccess(`Applied ${appliedChanges.length} change${appliedChanges.length !== 1 ? 's' : ''} to ${appliedZones.length} zone${appliedZones.length !== 1 ? 's' : ''}`);
+      }
+      setApplyFailures(failures);
+      showError(`Failed to apply changes to ${failures.length} zone${failures.length !== 1 ? 's' : ''}`);
+    }
+
+    setApplying(false);
   };
 
   const getChangeDescription = (change: PendingChange): string => {
@@ -296,15 +320,22 @@ function PendingChangesDrawer({
           </IconButton>
         </Box>
 
-        {error && (
-          <Alert severity="error" sx={{ mb: 2 }}>
-            {error}
+        {applyFailures.length > 0 && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setApplyFailures([])}>
+            <Typography variant="body2" sx={{ fontWeight: 'bold', mb: 0.5 }}>
+              Some zones failed to apply. Their changes are still pending below.
+            </Typography>
+            {applyFailures.map(failure => (
+              <Typography variant="body2" key={failure.zone}>
+                {failure.zone} ({failure.changeCount} change{failure.changeCount !== 1 ? 's' : ''}): {failure.message}
+              </Typography>
+            ))}
           </Alert>
         )}
 
         <List>
           {pendingChanges.map((change, index) => (
-            <React.Fragment key={(change as any).id || `change-${index}`}>
+            <React.Fragment key={change.id}>
               <ListItem
                 draggable
                 onDragStart={(e) => handleDragStart(e, index)}
@@ -318,7 +349,7 @@ function PendingChangesDrawer({
                   },
                   pr: 6
                 }}
-                onClick={() => toggleExpanded((change as any).id || `temp-${index}`)}
+                onClick={() => toggleExpanded(change.id)}
               >
                 <DragIndicator sx={{ mr: 1, cursor: 'grab', flexShrink: 0 }} />
                 <ListItemText
@@ -345,10 +376,10 @@ function PendingChangesDrawer({
                         size="small"
                         onClick={(e) => {
                           e.stopPropagation();
-                          toggleExpanded((change as any).id || `temp-${index}`);
+                          toggleExpanded(change.id);
                         }}
                       >
-                        {expandedItems[(change as any).id || `temp-${index}`] ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                        {expandedItems[change.id] ? <ExpandLessIcon /> : <ExpandMoreIcon />}
                       </IconButton>
                     </Stack>
                   }
@@ -380,7 +411,7 @@ function PendingChangesDrawer({
                   aria-label="delete"
                   onClick={(e) => {
                     e.stopPropagation();
-                    removePendingChange((change as any).id);
+                    removePendingChange(change.id);
                   }}
                   disabled={applying}
                   sx={{
@@ -392,7 +423,7 @@ function PendingChangesDrawer({
                 </IconButton>
               </ListItem>
               <Collapse
-                in={Boolean(expandedItems[(change as any).id || `temp-${index}`])}
+                in={Boolean(expandedItems[change.id])}
                 timeout="auto" 
                 unmountOnExit
               >
@@ -447,7 +478,7 @@ function PendingChangesDrawer({
             <Button
               variant="contained"
               color="primary"
-              onClick={handleApplyChanges}
+              onClick={() => setConfirmOpen(true)}
               disabled={applying}
               fullWidth
             >
@@ -468,6 +499,27 @@ function PendingChangesDrawer({
           </Box>
         )}
       </Box>
+      <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
+        <DialogTitle>Apply changes to live DNS?</DialogTitle>
+        <DialogContent>
+          <DialogContentText component="div">
+            {Object.entries(changesByZone).map(([zone, changes]) => (
+              <Typography variant="body2" key={zone}>
+                {zone}: {changes.length} change{changes.length !== 1 ? 's' : ''}
+              </Typography>
+            ))}
+            <Typography variant="body2" sx={{ mt: 1 }} color="text.secondary">
+              An automatic snapshot of each zone is taken before applying.
+            </Typography>
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmOpen(false)}>Cancel</Button>
+          <Button variant="contained" color="primary" onClick={handleApplyChanges} autoFocus>
+            Apply {pendingChanges.length} change{pendingChanges.length !== 1 ? 's' : ''}
+          </Button>
+        </DialogActions>
+      </Dialog>
       <Snackbar
         open={applyWarnings.length > 0}
         autoHideDuration={10000}

--- a/src/components/Snapshots.tsx
+++ b/src/components/Snapshots.tsx
@@ -758,7 +758,6 @@ function Snapshots() {
 
           if (partialMatch) {
             changes.push({
-              id: Date.now() + Math.random(),
               type: 'MODIFY',
               zone: selectedBackup.zone,
               keyId: keyForZone.id,
@@ -772,7 +771,6 @@ function Snapshots() {
             });
           } else {
             changes.push({
-              id: Date.now() + Math.random(),
               type: 'ADD',
               zone: selectedBackup.zone,
               keyId: keyForZone.id,
@@ -798,7 +796,6 @@ function Snapshots() {
 
         if (!inSnapshot) {
           changes.push({
-            id: Date.now() + Math.random(),
             type: 'DELETE',
             zone: selectedBackup.zone,
             keyId: keyForZone.id,

--- a/src/components/ZoneEditor.tsx
+++ b/src/components/ZoneEditor.tsx
@@ -238,7 +238,6 @@ function ZoneEditor() {
   const handleDeleteRecord = async (record: DNSRecord) => {
     try {
       const change = {
-        id: Date.now(),
         type: 'DELETE' as const,
         zone: selectedZone!,
         keyId: selectedKey!.id,
@@ -262,7 +261,6 @@ function ZoneEditor() {
 
       deletable.forEach(record => {
         const change = {
-          id: Date.now() + Math.random(),
           type: 'DELETE' as const,
           zone: selectedZone!,
           keyId: selectedKey!.id,
@@ -290,7 +288,6 @@ function ZoneEditor() {
   const handleEditSave = async (updatedRecord: DNSRecord) => {
     try {
       const change = {
-        id: Date.now(),
         type: 'MODIFY' as const,
         zone: selectedZone!,
         keyId: selectedKey!.id,
@@ -422,9 +419,10 @@ function ZoneEditor() {
       const { zones } = (event as CustomEvent<{ zones: string[] }>).detail;
 
       if (selectedZone && zones.includes(selectedZone)) {
+        // The event fires after the backend transaction completed, so the
+        // zone can be re-fetched immediately.
         setIsRefreshing(true);
-
-        setTimeout(async () => {
+        (async () => {
           try {
             await loadZoneRecords();
           } catch (error) {
@@ -433,7 +431,7 @@ function ZoneEditor() {
           } finally {
             setIsRefreshing(false);
           }
-        }, 2000);
+        })();
       }
     };
 

--- a/src/components/ZoneEditor.tsx
+++ b/src/components/ZoneEditor.tsx
@@ -1,5 +1,5 @@
 // src/components/ZoneEditor.tsx
-import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import {
   Box,
   Button,
@@ -168,9 +168,6 @@ function ZoneEditor() {
   const [multilineRecord, setMultilineRecord] = useState<DNSRecord | null>(null);
   const [changeHistory, setChangeHistory] = useState<any[][]>([[]]);
   const [historyIndex, setHistoryIndex] = useState<number>(0);
-  // Set when an apply commits changes; tells the history effect to restart
-  // rather than record the queue shrink as an undoable step.
-  const historyResetPendingRef = useRef(false);
   const [showAddRecord, setShowAddRecord] = useState<boolean>(false);
   const [addRecordDialogOpen, setAddRecordDialogOpen] = useState<boolean>(false);
   const [refreshing, setRefreshing] = useState<boolean>(false);
@@ -404,22 +401,13 @@ function ZoneEditor() {
     const currentChanges = JSON.stringify(pendingChanges);
     const historyChanges = JSON.stringify(changeHistory[historyIndex]);
 
-    if (currentChanges === historyChanges) return;
-
-    if (historyResetPendingRef.current) {
-      // Changes were just applied to live DNS; restart history from the
-      // current queue so undo can't resurrect committed changes.
-      historyResetPendingRef.current = false;
-      setChangeHistory([[...pendingChanges]]);
-      setHistoryIndex(0);
-      return;
+    if (currentChanges !== historyChanges) {
+      setChangeHistory(prev => {
+        const newHistory = prev.slice(0, historyIndex + 1);
+        return [...newHistory, [...pendingChanges]];
+      });
+      setHistoryIndex(prev => prev + 1);
     }
-
-    setChangeHistory(prev => {
-      const newHistory = prev.slice(0, historyIndex + 1);
-      return [...newHistory, [...pendingChanges]];
-    });
-    setHistoryIndex(prev => prev + 1);
   }, [pendingChanges, historyIndex]);
 
   const handleAddRecordClick = () => {
@@ -428,12 +416,16 @@ function ZoneEditor() {
 
   useEffect(() => {
     const handleChangesApplied = (event: Event) => {
-      const { zones } = (event as CustomEvent<{ zones: string[] }>).detail;
+      const { zones, changeIds } = (event as CustomEvent<{ zones: string[]; changeIds?: string[] }>).detail;
 
-      // Applied changes leave the pending queue; flag the history effect to
-      // restart so undo/redo can't bring them back (regardless of which
-      // zone is currently selected).
-      historyResetPendingRef.current = true;
+      // Purge the committed changes from every undo/redo history entry so
+      // no undo/redo path can resurrect them into the pending queue and
+      // risk a double-apply. Ids are unique, so this is safe regardless of
+      // timing relative to the drawer's own queue pruning.
+      if (changeIds?.length) {
+        const appliedIds = new Set(changeIds);
+        setChangeHistory(prev => prev.map(entry => entry.filter((c: any) => !appliedIds.has(c.id))));
+      }
 
       if (selectedZone && zones.includes(selectedZone)) {
         // The event fires after the backend transaction completed, so the

--- a/src/components/ZoneEditor.tsx
+++ b/src/components/ZoneEditor.tsx
@@ -1,5 +1,5 @@
 // src/components/ZoneEditor.tsx
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   Box,
   Button,
@@ -168,6 +168,9 @@ function ZoneEditor() {
   const [multilineRecord, setMultilineRecord] = useState<DNSRecord | null>(null);
   const [changeHistory, setChangeHistory] = useState<any[][]>([[]]);
   const [historyIndex, setHistoryIndex] = useState<number>(0);
+  // Set when an apply commits changes; tells the history effect to restart
+  // rather than record the queue shrink as an undoable step.
+  const historyResetPendingRef = useRef(false);
   const [showAddRecord, setShowAddRecord] = useState<boolean>(false);
   const [addRecordDialogOpen, setAddRecordDialogOpen] = useState<boolean>(false);
   const [refreshing, setRefreshing] = useState<boolean>(false);
@@ -401,13 +404,22 @@ function ZoneEditor() {
     const currentChanges = JSON.stringify(pendingChanges);
     const historyChanges = JSON.stringify(changeHistory[historyIndex]);
 
-    if (currentChanges !== historyChanges) {
-      setChangeHistory(prev => {
-        const newHistory = prev.slice(0, historyIndex + 1);
-        return [...newHistory, [...pendingChanges]];
-      });
-      setHistoryIndex(prev => prev + 1);
+    if (currentChanges === historyChanges) return;
+
+    if (historyResetPendingRef.current) {
+      // Changes were just applied to live DNS; restart history from the
+      // current queue so undo can't resurrect committed changes.
+      historyResetPendingRef.current = false;
+      setChangeHistory([[...pendingChanges]]);
+      setHistoryIndex(0);
+      return;
     }
+
+    setChangeHistory(prev => {
+      const newHistory = prev.slice(0, historyIndex + 1);
+      return [...newHistory, [...pendingChanges]];
+    });
+    setHistoryIndex(prev => prev + 1);
   }, [pendingChanges, historyIndex]);
 
   const handleAddRecordClick = () => {
@@ -417,6 +429,11 @@ function ZoneEditor() {
   useEffect(() => {
     const handleChangesApplied = (event: Event) => {
       const { zones } = (event as CustomEvent<{ zones: string[] }>).detail;
+
+      // Applied changes leave the pending queue; flag the history effect to
+      // restart so undo/redo can't bring them back (regardless of which
+      // zone is currently selected).
+      historyResetPendingRef.current = true;
 
       if (selectedZone && zones.includes(selectedZone)) {
         // The event fires after the backend transaction completed, so the

--- a/src/components/__tests__/PendingChangesDrawer.test.tsx
+++ b/src/components/__tests__/PendingChangesDrawer.test.tsx
@@ -1,0 +1,166 @@
+// src/components/__tests__/PendingChangesDrawer.test.tsx
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import PendingChangesDrawer from '../PendingChangesDrawer';
+import { PendingChangesProvider, usePendingChanges } from '../../context/PendingChangesContext';
+import { NewPendingChange } from '../../types/dns';
+import { dnsService } from '../../services/dnsService';
+
+jest.mock('../../services/dnsService', () => ({
+  dnsService: {
+    fetchZoneRecords: jest.fn().mockResolvedValue([]),
+    applyBatch: jest.fn()
+  }
+}));
+
+jest.mock('../../services/backupService', () => ({
+  backupService: {
+    createBackup: jest.fn().mockResolvedValue(undefined)
+  }
+}));
+
+jest.mock('../../services/notificationService', () => ({
+  notificationService: {
+    sendNotification: jest.fn().mockResolvedValue(undefined)
+  }
+}));
+
+jest.mock('../../services/tsigKeyService', () => ({
+  tsigKeyService: {
+    listKeys: jest.fn().mockResolvedValue([])
+  }
+}));
+
+const mockShowSuccess = jest.fn();
+const mockShowError = jest.fn();
+jest.mock('../../context/NotificationContext', () => ({
+  useNotification: () => ({ showSuccess: mockShowSuccess, showError: mockShowError })
+}));
+
+jest.mock('../../context/ConfigContext', () => ({
+  useConfig: () => ({ config: { keys: [] } })
+}));
+
+const applyBatch = dnsService.applyBatch as jest.Mock;
+
+const addChange = (zone: string, value: string): NewPendingChange => ({
+  type: 'ADD',
+  zone,
+  keyId: 'key-1',
+  record: { name: 'www', type: 'A', value, ttl: 300 } as any
+});
+
+function Harness({ seed, onClose }: { seed: NewPendingChange[]; onClose: () => void }) {
+  const ctx = usePendingChanges();
+  const seeded = React.useRef(false);
+  React.useEffect(() => {
+    if (!seeded.current) {
+      seeded.current = true;
+      seed.forEach(ctx.addPendingChange);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <PendingChangesDrawer
+      open
+      onClose={onClose}
+      removePendingChange={ctx.removePendingChange}
+      clearPendingChanges={ctx.clearPendingChanges}
+    />
+  );
+}
+
+const renderDrawer = (seed: NewPendingChange[], onClose: () => void = jest.fn()) =>
+  render(
+    <PendingChangesProvider>
+      <Harness seed={seed} onClose={onClose} />
+    </PendingChangesProvider>
+  );
+
+const startApply = async () => {
+  fireEvent.click(screen.getByRole('button', { name: 'Apply Changes' }));
+  // Confirmation dialog opens; the confirm button states the change count.
+  fireEvent.click(await screen.findByRole('button', { name: /^Apply \d+ change/ }));
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('PendingChangesDrawer apply flow', () => {
+  it('requires confirmation before applying, and cancel applies nothing', async () => {
+    renderDrawer([addChange('alpha.test', '192.0.2.1')]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply Changes' }));
+    expect(await screen.findByText('Apply changes to live DNS?')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() =>
+      expect(screen.queryByText('Apply changes to live DNS?')).not.toBeInTheDocument()
+    );
+    expect(applyBatch).not.toHaveBeenCalled();
+  });
+
+  it('applies all zones, clears the queue and closes on full success', async () => {
+    applyBatch.mockResolvedValue({});
+    const onClose = jest.fn();
+    renderDrawer(
+      [addChange('alpha.test', '192.0.2.1'), addChange('beta.test', '192.0.2.2')],
+      onClose
+    );
+
+    await startApply();
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(applyBatch).toHaveBeenCalledTimes(2);
+    expect(mockShowSuccess).toHaveBeenCalledWith('Successfully applied 2 changes to 2 zones');
+    expect(screen.getByText('Pending Changes (0)')).toBeInTheDocument();
+  });
+
+  it('keeps only the failed zone pending on partial failure', async () => {
+    // alpha.test succeeds, beta.test fails: alpha's changes must leave the
+    // queue (no double-apply on retry), beta's must remain with its error.
+    applyBatch.mockImplementation((zone: string) =>
+      zone === 'alpha.test'
+        ? Promise.resolve({})
+        : Promise.reject(new Error('update REFUSED'))
+    );
+    const onClose = jest.fn();
+    renderDrawer(
+      [addChange('alpha.test', '192.0.2.1'), addChange('beta.test', '192.0.2.2')],
+      onClose
+    );
+
+    await startApply();
+
+    expect(
+      await screen.findByText('Some zones failed to apply. Their changes are still pending below.')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/beta\.test \(1 change\): update REFUSED/)).toBeInTheDocument();
+
+    // Applied zone's change was removed; failed zone's change remains.
+    expect(screen.getByText('Pending Changes (1)')).toBeInTheDocument();
+    expect(screen.getByText(/Zone: beta\.test/)).toBeInTheDocument();
+    expect(screen.queryByText(/Zone: alpha\.test/)).not.toBeInTheDocument();
+
+    expect(mockShowError).toHaveBeenCalledWith('Failed to apply changes to 1 zone');
+    expect(mockShowSuccess).toHaveBeenCalledWith('Applied 1 change to 1 zone');
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('leaves everything pending when every zone fails', async () => {
+    applyBatch.mockRejectedValue(new Error('SERVFAIL'));
+    const onClose = jest.fn();
+    renderDrawer([addChange('alpha.test', '192.0.2.1')], onClose);
+
+    await startApply();
+
+    expect(
+      await screen.findByText('Some zones failed to apply. Their changes are still pending below.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Pending Changes (1)')).toBeInTheDocument();
+    expect(mockShowSuccess).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/context/PendingChangesContext.tsx
+++ b/src/context/PendingChangesContext.tsx
@@ -1,15 +1,23 @@
 // src/context/PendingChangesContext.tsx
 import React, { createContext, useContext, useState } from 'react';
-import { PendingChange } from '../types/dns';
+import { NewPendingChange, PendingChange } from '../types/dns';
 
 interface PendingChangesContextType {
   pendingChanges: PendingChange[];
   setPendingChanges: React.Dispatch<React.SetStateAction<PendingChange[]>>;
-  addPendingChange: (change: PendingChange) => void;
+  addPendingChange: (change: NewPendingChange) => void;
   removePendingChange: (changeId: string) => void;
   clearPendingChanges: () => void;
   showPendingDrawer: boolean;
   setShowPendingDrawer: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+// Stamp a unique id so each queued change can be removed individually.
+function generateChangeId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `chg-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
 const PendingChangesContext = createContext<PendingChangesContextType | undefined>(undefined);
@@ -18,12 +26,13 @@ export function PendingChangesProvider({ children }: { children: React.ReactNode
   const [pendingChanges, setPendingChanges] = useState<PendingChange[]>([]);
   const [showPendingDrawer, setShowPendingDrawer] = useState(false);
 
-  const addPendingChange = (change: PendingChange) => {
-    setPendingChanges(prev => [...prev, change]);
+  const addPendingChange = (change: NewPendingChange) => {
+    const stamped: PendingChange = { ...change, id: change.id ?? generateChangeId() };
+    setPendingChanges(prev => [...prev, stamped]);
   };
 
   const removePendingChange = (changeId: string) => {
-    setPendingChanges(prev => prev.filter((change: any) => change.id !== changeId));
+    setPendingChanges(prev => prev.filter(change => change.id !== changeId));
   };
 
   const clearPendingChanges = () => {

--- a/src/context/__tests__/PendingChangesContext.test.tsx
+++ b/src/context/__tests__/PendingChangesContext.test.tsx
@@ -1,0 +1,70 @@
+// src/context/__tests__/PendingChangesContext.test.tsx
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { PendingChangesProvider, usePendingChanges } from '../PendingChangesContext';
+import { NewPendingChange } from '../../types/dns';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <PendingChangesProvider>{children}</PendingChangesProvider>
+);
+
+const makeChange = (value: string): NewPendingChange => ({
+  type: 'ADD',
+  zone: 'example.com',
+  keyId: 'key-1',
+  record: { name: 'www', type: 'A', value, ttl: 300 } as any
+});
+
+describe('PendingChangesContext id stamping', () => {
+  it('stamps a unique id on every added change', () => {
+    const { result } = renderHook(() => usePendingChanges(), { wrapper });
+
+    act(() => {
+      result.current.addPendingChange(makeChange('192.0.2.1'));
+      result.current.addPendingChange(makeChange('192.0.2.2'));
+    });
+
+    const [first, second] = result.current.pendingChanges;
+    expect(first.id).toEqual(expect.any(String));
+    expect(second.id).toEqual(expect.any(String));
+    expect(first.id).not.toEqual(second.id);
+  });
+
+  it('removes only the targeted change, not all changes added without ids', () => {
+    // Regression: ADD/COPY changes used to be queued without ids, so removing
+    // one filtered out every id-less change at once.
+    const { result } = renderHook(() => usePendingChanges(), { wrapper });
+
+    act(() => {
+      result.current.addPendingChange(makeChange('192.0.2.1'));
+      result.current.addPendingChange(makeChange('192.0.2.2'));
+      result.current.addPendingChange(makeChange('192.0.2.3'));
+    });
+
+    const middleId = result.current.pendingChanges[1].id;
+    act(() => {
+      result.current.removePendingChange(middleId);
+    });
+
+    expect(result.current.pendingChanges).toHaveLength(2);
+    expect(result.current.pendingChanges.map(c => (c.record as any).value)).toEqual([
+      '192.0.2.1',
+      '192.0.2.3'
+    ]);
+  });
+
+  it('clearPendingChanges empties the queue and closes the drawer', () => {
+    const { result } = renderHook(() => usePendingChanges(), { wrapper });
+
+    act(() => {
+      result.current.addPendingChange(makeChange('192.0.2.1'));
+      result.current.setShowPendingDrawer(true);
+    });
+    act(() => {
+      result.current.clearPendingChanges();
+    });
+
+    expect(result.current.pendingChanges).toHaveLength(0);
+    expect(result.current.showPendingDrawer).toBe(false);
+  });
+});

--- a/src/types/dns.ts
+++ b/src/types/dns.ts
@@ -43,7 +43,10 @@ export interface DNSRecord {
 
 // Pending change interface for tracking modifications
 export interface PendingChange {
-  type: 'ADD' | 'MODIFY' | 'DELETE';
+  // Unique id stamped by PendingChangesContext.addPendingChange; required so
+  // individual changes can be removed without affecting others.
+  id: string;
+  type: 'ADD' | 'MODIFY' | 'DELETE' | 'RESTORE';
   zone: string;
   keyId: string;
   record?: DNSRecord;
@@ -53,7 +56,16 @@ export interface PendingChange {
   recordType?: RecordType;
   value?: string;
   ttl?: number;
+  // Provenance for changes queued from a snapshot restore
+  source?: {
+    type: string;
+    id: string | number;
+    timestamp: number;
+  };
 }
+
+// Input shape for queueing a change — id is assigned by the context.
+export type NewPendingChange = Omit<PendingChange, 'id'> & { id?: string };
 
 // Validation result interface
 export interface ValidationResult {


### PR DESCRIPTION
## Summary

Overhauls the apply flow — the point where queued changes are committed to live DNS — to eliminate several ways it could mislead the user or double-apply changes.

- **Delete-one-removes-all**: pending changes queued via Add/Copy had no `id`, and the drawer's remove button filters by id — removing one id-less change removed them all. `PendingChange.id` is now a required string stamped centrally in `addPendingChange`.
- **Double-apply on partial failure**: apply used to abort at the first failing zone and only clear the queue on full success, so already-committed zones still looked "pending" and a retry re-applied them. Zones now apply independently; committed changes leave the queue even when other zones fail, and failed zones stay pending with their error shown in the drawer.
- **Undo/redo resurrection**: the queue history could restore already-applied changes via Undo/Redo. The `dnsChangesApplied` event now carries the applied change ids and ZoneEditor purges them from every history entry, closing this regardless of timing.
- **Confirmation before commit**: applying now shows a dialog summarizing change counts per zone before touching live DNS.
- **Immediate refresh**: the zone view refreshes as soon as the backend transaction completes instead of after a blind 2-second timer.

## Testing

- 7 new tests: `PendingChangesContext` (unique id stamping, targeted removal regression, clear) and `PendingChangesDrawer` (confirmation gate, full-success clear/close, partial failure keeps only the failed zone pending, all-zones-failed leaves queue intact).
- Full frontend suite: 141 tests green; `tsc --noEmit` clean; no new lint warnings.
- Branch diff independently code-reviewed; the one high-severity finding (undo/redo race during in-flight apply) is fixed by the id-purge commit.