### PR TITLE
fix(ui): apply-flow follow-ups and zone editor selection safety

### DIFF
--- a/src/components/AddDNSRecord.tsx
+++ b/src/components/AddDNSRecord.tsx
@@ -58,8 +58,10 @@ const RECORD_TYPES: Record<string, RecordTypeDefinition> = {
     fields: [{
       name: 'value',
       label: 'IPv6 Address',
-      helperText: 'Enter a valid IPv6 address',
-      validate: (value) => /^(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}$/i.test(value),
+      helperText: 'Enter a valid IPv6 address (compressed forms like 2001:db8::1 are fine)',
+      // Delegate to the shared validator so compressed (::) and
+      // embedded-IPv4 forms aren't falsely rejected.
+      validate: (value) => DNSValidationService.isValidIPv6(value),
       required: true
     }]
   },

--- a/src/components/AddDNSRecord.tsx
+++ b/src/components/AddDNSRecord.tsx
@@ -16,7 +16,6 @@ import {
 } from '@mui/material';
 import { usePendingChanges } from '../context/PendingChangesContext';
 import { useKey } from '../context/KeyContext';
-import { dnsService } from '../services/dnsService';
 import { useConfig } from '../context/ConfigContext';
 import { DNSValidationService } from '../services/dnsValidationService';
 import { DNSRecordFormatter } from '../services/dnsRecordFormatter';
@@ -255,7 +254,7 @@ type ErrorState = string | { severity?: string; message: string; details?: any }
 
 function AddDNSRecord({ zone, onSuccess, onClose }: AddDNSRecordProps) {
   const { selectedKey, selectedZone } = useKey();
-  const { addPendingChange, setShowPendingDrawer, pendingChanges } = usePendingChanges();
+  const { addPendingChange, pendingChanges } = usePendingChanges();
   const { config } = useConfig();
   const [record, setRecord] = useState<Record<string, any>>({
     name: '',

--- a/src/components/PendingChangesDrawer.tsx
+++ b/src/components/PendingChangesDrawer.tsx
@@ -15,7 +15,6 @@ import {
   Stack,
   Collapse,
   Snackbar,
-  Tooltip,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -307,7 +306,9 @@ function PendingChangesDrawer({
     <Drawer
       anchor="right"
       open={open}
-      onClose={onClose}
+      // Keep the drawer up while an apply is in flight so its progress and
+      // any per-zone failures stay visible.
+      onClose={applying ? undefined : onClose}
       PaperProps={{
         sx: { width: 400 }
       }}
@@ -317,7 +318,7 @@ function PendingChangesDrawer({
           <Typography variant="h6">
             Pending Changes ({pendingChanges.length})
           </Typography>
-          <IconButton onClick={onClose} size="small" aria-label="Close">
+          <IconButton onClick={onClose} size="small" aria-label="Close" disabled={applying}>
             <CloseIcon />
           </IconButton>
         </Box>

--- a/src/components/PendingChangesDrawer.tsx
+++ b/src/components/PendingChangesDrawer.tsx
@@ -201,7 +201,7 @@ function PendingChangesDrawer({
     // Send a single notification for all successful changes
     if (appliedChanges.length > 0) {
       try {
-        await notificationService.sendNotification('Multiple Zones', {
+        await notificationService.sendNotification(appliedZones.length === 1 ? appliedZones[0] : 'Multiple Zones', {
           changes: appliedChanges,
           zones: appliedZones,
           timestamp: Date.now(),

--- a/src/components/ZoneEditor.tsx
+++ b/src/components/ZoneEditor.tsx
@@ -36,7 +36,6 @@ import { useConfig } from '../context/ConfigContext';
 import { dnsService } from '../services/dnsService';
 import AddDNSRecord from './AddDNSRecord';
 import { usePendingChanges } from '../context/PendingChangesContext';
-import { backupService } from '../services/backupService';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import SearchIcon from '@mui/icons-material/Search';
 import UndoIcon from '@mui/icons-material/Undo';
@@ -151,11 +150,8 @@ function ZoneEditor() {
   const [records, setRecords] = useState<DNSRecord[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
-  const [showPreview, setShowPreview] = useState<boolean>(false);
-  const [filter, setFilter] = useState<string>('');
   const [page, setPage] = useState<number>(0);
   const [rowsPerPage, setRowsPerPage] = useState<number>(config.rowsPerPage || 10);
-  const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
   const [searchText, setSearchText] = useState<string>('');
   const [filterType, setFilterType] = useState<string>('ALL');
   const [selectedRecords, setSelectedRecords] = useState<DNSRecord[]>([]);
@@ -164,7 +160,6 @@ function ZoneEditor() {
   const [multilineRecord, setMultilineRecord] = useState<DNSRecord | null>(null);
   const [changeHistory, setChangeHistory] = useState<any[][]>([[]]);
   const [historyIndex, setHistoryIndex] = useState<number>(0);
-  const [showAddRecord, setShowAddRecord] = useState<boolean>(false);
   const [addRecordDialogOpen, setAddRecordDialogOpen] = useState<boolean>(false);
   const [refreshing, setRefreshing] = useState<boolean>(false);
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
@@ -308,14 +303,6 @@ function ZoneEditor() {
     }
   };
 
-  const formatRecordValue = (record: DNSRecord): string => {
-    if (record.type === 'SOA') {
-      const soa = record.value as any;
-      return `${soa.mname} ${soa.rname} ${soa.serial} ${soa.refresh} ${soa.retry} ${soa.expire} ${soa.minimum}`;
-    }
-    return record.value as string;
-  };
-
   const isMultilineRecord = (record: DNSRecord | null): boolean => {
     if (!record) return false;
 
@@ -335,7 +322,7 @@ function ZoneEditor() {
   };
 
   const sortRecords = (records: DNSRecord[]): DNSRecord[] => {
-    return records.sort((a, b) => {
+    return [...records].sort((a, b) => {
       let aValue: any = a[orderBy];
       let bValue: any = b[orderBy];
 
@@ -362,6 +349,12 @@ function ZoneEditor() {
     });
   };
 
+  // A changed search/filter can strand the user on a now-empty page and
+  // leave hidden records selected (which a bulk delete would still act on).
+  useEffect(() => {
+    setPage(0);
+  }, [searchText, filterType]);
+
   const filteredRecords = useMemo(() => {
     const filtered = records.filter(record => {
       const searchLower = searchText.toLowerCase();
@@ -379,6 +372,15 @@ function ZoneEditor() {
 
     return sortRecords(filtered);
   }, [records, searchText, filterType, order, orderBy]);
+
+  // Drop selections that the current filter hides, so bulk actions only
+  // ever operate on records the user can see.
+  useEffect(() => {
+    setSelectedRecords(prev => {
+      const visible = prev.filter(r => filteredRecords.includes(r));
+      return visible.length === prev.length ? prev : visible;
+    });
+  }, [filteredRecords]);
 
   const canUndo = historyIndex > 0;
   const canRedo = historyIndex < changeHistory.length - 1;

--- a/src/components/ZoneEditor.tsx
+++ b/src/components/ZoneEditor.tsx
@@ -44,7 +44,6 @@ import RedoIcon from '@mui/icons-material/Redo';
 import RecordEditor from './RecordEditor';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { useKey } from '../context/KeyContext';
-import PendingChangesDrawer from './PendingChangesDrawer';
 import { DNSRecord, RecordType } from '../types/dns';
 
 // Sourced from the RecordType enum so the type filter stays in sync with the
@@ -140,9 +139,6 @@ function ZoneEditor() {
     pendingChanges,
     setPendingChanges,
     addPendingChange,
-    removePendingChange,
-    clearPendingChanges,
-    showPendingDrawer,
     setShowPendingDrawer
   } = usePendingChanges();
 
@@ -205,7 +201,11 @@ function ZoneEditor() {
         selectedKey &&
         availableZones.includes(selectedZone) &&
         !isInitializing) {
-      loadZoneRecords();
+      // Table-level loading indicator for the initial fetch of a zone;
+      // manual refreshes and post-apply refreshes keep the table visible
+      // and use their own indicators instead.
+      setLoading(true);
+      loadZoneRecords().finally(() => setLoading(false));
     }
   }, [selectedZone, selectedKey, availableZones, isInitializing, loadZoneRecords]);
 
@@ -813,12 +813,6 @@ function ZoneEditor() {
         </Button>
       </Box>
 
-      <PendingChangesDrawer
-        open={showPendingDrawer}
-        onClose={() => setShowPendingDrawer(false)}
-        removePendingChange={removePendingChange}
-        clearPendingChanges={clearPendingChanges}
-      />
     </Paper>
   );
 }

--- a/src/components/ZoneEditor.tsx
+++ b/src/components/ZoneEditor.tsx
@@ -211,7 +211,9 @@ function ZoneEditor() {
 
   const handleSelectAllClick = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.checked) {
-      setSelectedRecords(records);
+      // Select only what the current search/filter shows — selecting hidden
+      // records would let a bulk delete queue changes the user never saw.
+      setSelectedRecords(filteredRecords);
     } else {
       setSelectedRecords([]);
     }
@@ -481,6 +483,17 @@ function ZoneEditor() {
 
   return (
     <Paper sx={{ p: 3 }}>
+      {selectedZone && selectedKey && (
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5, mb: 2, flexWrap: 'wrap' }}>
+          <Typography variant="h5" component="h1">{selectedZone}</Typography>
+          <Typography variant="body2" color="text.secondary">
+            key: {selectedKey.name} · server: {selectedKey.server}
+            {records.length > 0 && (filteredRecords.length === records.length
+              ? ` · ${records.length} record${records.length !== 1 ? 's' : ''}`
+              : ` · showing ${filteredRecords.length} of ${records.length} records`)}
+          </Typography>
+        </Box>
+      )}
       <Box sx={{
         display: 'flex',
         gap: 2,
@@ -613,8 +626,8 @@ function ZoneEditor() {
                   <TableCell padding="checkbox">
                     <Checkbox
                       size="small"
-                      indeterminate={selectedRecords.length > 0 && selectedRecords.length < records.length}
-                      checked={records.length > 0 && selectedRecords.length === records.length}
+                      indeterminate={selectedRecords.length > 0 && selectedRecords.length < filteredRecords.length}
+                      checked={filteredRecords.length > 0 && selectedRecords.length === filteredRecords.length}
                       onChange={handleSelectAllClick}
                     />
                   </TableCell>
@@ -658,6 +671,15 @@ function ZoneEditor() {
                 </TableRow>
               </TableHead>
               <TableBody>
+                {filteredRecords.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={6} align="center" sx={{ py: 6, color: 'text.secondary' }}>
+                      {records.length === 0
+                        ? 'No records in this zone yet. Use "Add Record" to create one.'
+                        : 'No records match the current search or type filter.'}
+                    </TableCell>
+                  </TableRow>
+                )}
                 {filteredRecords
                   .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
                   .map((record, index) => (

--- a/src/components/__tests__/PendingChangesDrawer.test.tsx
+++ b/src/components/__tests__/PendingChangesDrawer.test.tsx
@@ -5,6 +5,7 @@ import PendingChangesDrawer from '../PendingChangesDrawer';
 import { PendingChangesProvider, usePendingChanges } from '../../context/PendingChangesContext';
 import { NewPendingChange } from '../../types/dns';
 import { dnsService } from '../../services/dnsService';
+import { notificationService } from '../../services/notificationService';
 
 jest.mock('../../services/dnsService', () => ({
   dnsService: {
@@ -115,6 +116,10 @@ describe('PendingChangesDrawer apply flow', () => {
     await waitFor(() => expect(onClose).toHaveBeenCalled());
     expect(applyBatch).toHaveBeenCalledTimes(2);
     expect(mockShowSuccess).toHaveBeenCalledWith('Successfully applied 2 changes to 2 zones');
+    expect(notificationService.sendNotification).toHaveBeenCalledWith(
+      'Multiple Zones',
+      expect.objectContaining({ zones: ['alpha.test', 'beta.test'] })
+    );
     expect(screen.getByText('Pending Changes (0)')).toBeInTheDocument();
   });
 
@@ -146,6 +151,11 @@ describe('PendingChangesDrawer apply flow', () => {
 
     expect(mockShowError).toHaveBeenCalledWith('Failed to apply changes to 1 zone');
     expect(mockShowSuccess).toHaveBeenCalledWith('Applied 1 change to 1 zone');
+    // Single-zone applies name the zone in the webhook notification.
+    expect(notificationService.sendNotification).toHaveBeenCalledWith(
+      'alpha.test',
+      expect.objectContaining({ zones: ['alpha.test'] })
+    );
     expect(onClose).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Two batches of UX/correctness fixes.

### Apply-flow follow-ups (from the PR #24 code review)

- **Single drawer mount**: `PendingChangesDrawer` was rendered by both `Layout` and `ZoneEditor`, giving two live instances bound to the same context state — duplicated mount side effects and two independent `applying`/`confirmOpen` states over one queue. The `ZoneEditor` instance is removed; `Layout`'s global one remains.
- **Real loading state**: `ZoneEditor`'s `loading` state was never set, so the table rendered blank during a zone's initial fetch and the `loading` gate on Undo/Redo was dead. It's now set around the initial fetch of a selected zone; manual and post-apply refreshes keep the table visible with their existing indicators.
- **Webhook label**: single-zone applies now pass the zone name to `notificationService.sendNotification` instead of the hardcoded `'Multiple Zones'`; both cases asserted in the drawer tests.

### Zone editor selection safety and clarity

- **Select-all respects the active filter**: it previously selected the entire zone regardless of search/type filter, so a filtered bulk delete could queue deletions of records the user never saw. It now selects only the visible (filtered) records, and the header checkbox's checked/indeterminate math uses the filtered list.
- **Empty states**: empty zones and no-match filters show an explanatory row instead of a blank table.
- **AAAA validation**: the add-record form's inline IPv6 regex only accepted the full 8-group form, falsely rejecting compressed addresses like `2001:db8::1`. It now delegates to the shared `DNSValidationService.isValidIPv6`.
- **Active-zone header**: the zone editor shows the zone being edited, the key and server in use, and the record count (filtered vs total) — previously the active zone was visible only in the sidebar.

## Testing

141 frontend tests green; `tsc --noEmit` clean; no new lint warnings.

### Quick wins

- Search/filter changes reset pagination to page 0 and drop selections the new filter hides (bulk actions only ever act on visible records).
- The drawer cannot be dismissed while an apply is in flight, keeping progress and per-zone failures visible.
- `sortRecords` sorts a copy instead of mutating React state in place.
- Dead-code sweep: unused state, functions, and imports removed; lint warnings in the touched files drop from 14 to 2 pre-existing exhaustive-deps notes.
