### PR TITLE
fix(ui): consistent destructive-action confirmations

### DIFF
--- a/src/components/AddDNSRecord.tsx
+++ b/src/components/AddDNSRecord.tsx
@@ -250,7 +250,7 @@ interface AddDNSRecordProps {
   onClose?: () => void;
 }
 
-type ErrorState = string | { severity?: string; message: string; details?: any } | null;
+type ErrorState = string | { severity?: string; message: string } | null;
 
 function AddDNSRecord({ zone, onSuccess, onClose }: AddDNSRecordProps) {
   const { selectedKey, selectedZone } = useKey();
@@ -714,19 +714,6 @@ function AddDNSRecord({ zone, onSuccess, onClose }: AddDNSRecordProps) {
         <Alert
           severity={(typeof error === 'object' && error !== null ? error.severity : undefined) as any || 'error'}
           sx={{ mt: 2 }}
-          action={
-            typeof error === 'object' && error !== null && error.details ? (
-              <Button
-                color="inherit"
-                size="small"
-                onClick={() => {
-                  console.info('Error details:', (error as { severity?: string; message: string; details?: any }).details);
-                }}
-              >
-                Details
-              </Button>
-            ) : undefined
-          }
         >
           {typeof error === 'string' ? error : error.message}
         </Alert>

--- a/src/components/Snapshots.tsx
+++ b/src/components/Snapshots.tsx
@@ -327,6 +327,8 @@ function Snapshots() {
   const [importDialogOpen, setImportDialogOpen] = useState<boolean>(false);
   const [importFile, setImportFile] = useState<File | null>(null);
   const [importing, setImporting] = useState<boolean>(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState<boolean>(false);
+  const [backupToDelete, setBackupToDelete] = useState<any>(null);
 
   useEffect(() => {
     const loadKeys = async () => {
@@ -441,17 +443,25 @@ function Snapshots() {
     }
   };
 
-  const handleDeleteBackup = async (backup: any) => {
-    if (window.confirm('Are you sure you want to delete this snapshot?')) {
-      try {
-        await backupService.deleteBackup(backup.zone, backup.id);
-        const backupList = await backupService.getBackups();
-        setBackups(backupList);
-        setSuccess('Snapshot deleted successfully');
-      } catch (error) {
-        setError(`Failed to delete snapshot: ${(error as Error).message}`);
-        console.error('Delete backup error:', error);
-      }
+  const handleDeleteBackup = (backup: any) => {
+    setBackupToDelete(backup);
+    setDeleteDialogOpen(true);
+  };
+
+  const confirmDeleteBackup = async () => {
+    if (!backupToDelete) return;
+
+    try {
+      await backupService.deleteBackup(backupToDelete.zone, backupToDelete.id);
+      const backupList = await backupService.getBackups();
+      setBackups(backupList);
+      setSuccess('Snapshot deleted successfully');
+    } catch (error) {
+      setError(`Failed to delete snapshot: ${(error as Error).message}`);
+      console.error('Delete backup error:', error);
+    } finally {
+      setDeleteDialogOpen(false);
+      setBackupToDelete(null);
     }
   };
 
@@ -1553,6 +1563,37 @@ function Snapshots() {
             startIcon={importing ? <CircularProgress size={20} /> : <UploadIcon />}
           >
             {importing ? 'Importing...' : 'Import'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog
+        open={deleteDialogOpen}
+        onClose={() => {
+          setDeleteDialogOpen(false);
+          setBackupToDelete(null);
+        }}
+      >
+        <DialogTitle>Delete Snapshot</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete the snapshot for "{backupToDelete?.zone}" from{' '}
+            {backupToDelete ? new Date(backupToDelete.timestamp).toLocaleString() : ''}? This
+            action cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              setDeleteDialogOpen(false);
+              setBackupToDelete(null);
+            }}
+          >
+            Cancel
+          </Button>
+          <Button onClick={confirmDeleteBackup} color="error" variant="contained">
+            Delete
           </Button>
         </DialogActions>
       </Dialog>


### PR DESCRIPTION
## Summary

Unifies the app's destructive-action confirmation patterns (previously three different ones):

- **Snapshot delete** — the only remaining `window.confirm` in the frontend (whole-tree grep) is replaced with an MUI confirmation dialog matching the TSIGKeyManagement pattern: names the zone and snapshot timestamp, Cancel + error-colored Delete, state cleanup in `finally`.
- **AddDNSRecord error "Details" button** — its onClick only did `console.info`, a dead affordance; removed along with the unreachable `details` field on the error state (audited every `setError` call site — nothing ever set it).

Delete feedback stays on exactly one channel (the existing local success Alert).

## Testing

`tsc --noEmit` clean; 141 frontend tests green; eslint on touched files shows only the pre-existing baseline warnings (stash-compared).