### PR TITLE
feat(ui): predictable zone-first key/zone selection

### DIFF
--- a/src/components/KeySelector.tsx
+++ b/src/components/KeySelector.tsx
@@ -135,7 +135,6 @@ function KeySelector() {
           value={validSelectedZone}
           onChange={(e) => selectZone(e.target.value || null)}
           label="Select Zone"
-          disabled={!selectedKey}
           SelectDisplayProps={{ id: 'zone-select' } as React.HTMLAttributes<HTMLDivElement>}
         >
           <MenuItem value="">
@@ -150,7 +149,9 @@ function KeySelector() {
             ))}
         </Select>
         <FormHelperText>
-          {!selectedKey ? 'Select a key first' : 'Select a zone to manage'}
+          {!selectedKey
+            ? 'Select a zone and a matching key is chosen automatically'
+            : 'Select a zone to manage'}
         </FormHelperText>
       </FormControl>
 

--- a/src/context/KeyContext.tsx
+++ b/src/context/KeyContext.tsx
@@ -20,6 +20,9 @@ interface KeyContextType {
   selectedZone: string | null;
   selectKey: (key: AvailableKey | null) => void;
   selectZone: (zone: string | null) => void;
+  // availableZones is ALWAYS the union of zones across all keys, regardless of
+  // whether a key is selected. Consumers that need only the selected key's
+  // zones should read selectedKey.zones directly.
   availableZones: string[];
   availableKeys: AvailableKey[];
 }
@@ -55,7 +58,8 @@ export function KeyProvider({ children }: { children: React.ReactNode }) {
     fetchKeys();
   }, [isAuthenticated]);
 
-  // Calculate available keys and zones
+  // Calculate available keys and zones. availableZones is the union of zones
+  // across all keys (key-agnostic) so zone-first selection can list everything.
   const availableZones = React.useMemo(() => {
     const zones = new Set<string>();
     const keysToUse: any[] = backendKeys.length > 0 ? backendKeys : (config.keys || []);
@@ -79,11 +83,6 @@ export function KeyProvider({ children }: { children: React.ReactNode }) {
     }));
   }, [backendKeys, config.keys]);
 
-  const availableZonesForKey = React.useMemo(() => {
-    if (!selectedKey) return availableZones;
-    return selectedKey.zones || [];
-  }, [selectedKey, availableZones]);
-
   // Load saved selections on mount - wait for availableKeys to be populated
   useEffect(() => {
     if (!initialized && availableKeys.length > 0) {
@@ -97,6 +96,12 @@ export function KeyProvider({ children }: { children: React.ReactNode }) {
             if (saved.zone && savedKey.zones?.includes(saved.zone)) {
               setSelectedZone(saved.zone);
             }
+          }
+        } else if (saved.zone) {
+          // Zone-only selection (zone-first flow with the key deselected)
+          const zoneStillExists = availableKeys.some(k => k.zones?.includes(saved.zone));
+          if (zoneStillExists) {
+            setSelectedZone(saved.zone);
           }
         }
       } catch (error) {
@@ -129,11 +134,11 @@ export function KeyProvider({ children }: { children: React.ReactNode }) {
     }
   }, [availableKeys, selectedKey, selectedZone, initialized]);
 
-  // Save selections to localStorage
+  // Save selections to localStorage; shape stays { keyId, zone }
   const saveSelections = (key: AvailableKey | null, zone: string | null) => {
-    if (key) {
+    if (key || zone) {
       localStorage.setItem(STORAGE_KEY, JSON.stringify({
-        keyId: key.id,
+        keyId: key ? key.id : null,
         zone: zone
       }));
     } else {
@@ -141,24 +146,29 @@ export function KeyProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
+  // Selection transition rules:
+  // - selectKey(key): the current zone is KEPT when the new key serves it;
+  //   it is cleared only when the new key does not serve it. Deselecting the
+  //   key (null) keeps the zone (zone-first state).
+  // - selectZone(zone): the current key is KEPT when it serves the zone;
+  //   otherwise the first available key serving the zone is auto-selected.
+  //   Deselecting the zone (null) keeps the key.
   const selectKey = (key: AvailableKey | null) => {
+    const keepZone = !key || !selectedZone || key.zones?.includes(selectedZone);
+    const nextZone = keepZone ? selectedZone : null;
     setSelectedKey(key);
-    if (key && selectedZone && !key.zones?.includes(selectedZone)) {
-      setSelectedZone(null);
-      saveSelections(key, null);
-    } else {
-      saveSelections(key, selectedZone);
-    }
+    setSelectedZone(nextZone);
+    saveSelections(key, nextZone);
   };
 
   const selectZone = (zone: string | null) => {
+    const keepKey = !zone || (selectedKey?.zones?.includes(zone) ?? false);
+    const nextKey = keepKey
+      ? selectedKey
+      : availableKeys.find(k => k.zones?.includes(zone!)) || null;
+    setSelectedKey(nextKey);
     setSelectedZone(zone);
-    if (zone && selectedKey && !selectedKey.zones?.includes(zone)) {
-      setSelectedKey(null);
-      saveSelections(null, zone);
-    } else {
-      saveSelections(selectedKey, zone);
-    }
+    saveSelections(nextKey, zone);
   };
 
   return (

--- a/src/context/__tests__/KeyContext.test.tsx
+++ b/src/context/__tests__/KeyContext.test.tsx
@@ -1,0 +1,158 @@
+// src/context/__tests__/KeyContext.test.tsx
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { KeyProvider, useKey } from '../KeyContext';
+
+// Keys come from ConfigContext (backend fetch is skipped when unauthenticated),
+// so the provider resolves availableKeys synchronously in tests.
+jest.mock('../AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: false })
+}));
+
+jest.mock('../../services/tsigKeyService', () => ({
+  tsigKeyService: { listKeys: jest.fn().mockResolvedValue([]) }
+}));
+
+const mockKeyA = {
+  id: 'key-a',
+  name: 'Key A',
+  server: 'ns1.example.com',
+  keyName: 'key-a',
+  keyValue: 'secret-a',
+  algorithm: 'hmac-sha256',
+  zones: ['example.com', 'shared.com'],
+  type: 'internal'
+};
+
+const mockKeyB = {
+  id: 'key-b',
+  name: 'Key B',
+  server: 'ns2.example.com',
+  keyName: 'key-b',
+  keyValue: 'secret-b',
+  algorithm: 'hmac-sha256',
+  zones: ['other.org', 'shared.com'],
+  type: 'internal'
+};
+
+jest.mock('../ConfigContext', () => ({
+  useConfig: () => ({ config: { keys: [mockKeyA, mockKeyB] } })
+}));
+
+const STORAGE_KEY = 'dns_manager_selections';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <KeyProvider>{children}</KeyProvider>
+);
+
+describe('KeyContext selection transitions', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('lists all zones across all keys when no key is selected', () => {
+    const { result } = renderHook(() => useKey(), { wrapper });
+
+    expect(result.current.selectedKey).toBeNull();
+    expect(result.current.availableZones.sort()).toEqual([
+      'example.com',
+      'other.org',
+      'shared.com'
+    ]);
+  });
+
+  it('keeps the selected zone when switching to a key that serves it', () => {
+    const { result } = renderHook(() => useKey(), { wrapper });
+
+    act(() => {
+      result.current.selectKey(result.current.availableKeys[0]);
+      result.current.selectZone('shared.com');
+    });
+    act(() => {
+      result.current.selectKey(result.current.availableKeys[1]);
+    });
+
+    expect(result.current.selectedKey?.id).toBe('key-b');
+    expect(result.current.selectedZone).toBe('shared.com');
+  });
+
+  it('clears the zone only when the new key does not serve it', () => {
+    const { result } = renderHook(() => useKey(), { wrapper });
+
+    act(() => {
+      result.current.selectKey(result.current.availableKeys[0]);
+      result.current.selectZone('example.com');
+    });
+    act(() => {
+      result.current.selectKey(result.current.availableKeys[1]);
+    });
+
+    expect(result.current.selectedKey?.id).toBe('key-b');
+    expect(result.current.selectedZone).toBeNull();
+  });
+
+  it('auto-selects a serving key on zone-first selection', () => {
+    const { result } = renderHook(() => useKey(), { wrapper });
+
+    act(() => {
+      result.current.selectZone('other.org');
+    });
+
+    expect(result.current.selectedZone).toBe('other.org');
+    expect(result.current.selectedKey?.id).toBe('key-b');
+  });
+
+  it('keeps the current key when it serves the newly selected zone', () => {
+    const { result } = renderHook(() => useKey(), { wrapper });
+
+    act(() => {
+      result.current.selectKey(result.current.availableKeys[1]);
+    });
+    act(() => {
+      result.current.selectZone('shared.com');
+    });
+
+    // key-a also serves shared.com but the already-selected key-b must win
+    expect(result.current.selectedKey?.id).toBe('key-b');
+    expect(result.current.selectedZone).toBe('shared.com');
+  });
+
+  it('keeps the zone when the key is deselected', () => {
+    const { result } = renderHook(() => useKey(), { wrapper });
+
+    act(() => {
+      result.current.selectZone('example.com');
+    });
+    act(() => {
+      result.current.selectKey(null);
+    });
+
+    expect(result.current.selectedKey).toBeNull();
+    expect(result.current.selectedZone).toBe('example.com');
+  });
+
+  it('persists selections with the { keyId, zone } shape', () => {
+    const { result } = renderHook(() => useKey(), { wrapper });
+
+    act(() => {
+      result.current.selectZone('shared.com');
+    });
+
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual({
+      keyId: 'key-a',
+      zone: 'shared.com'
+    });
+  });
+
+  it('restores a persisted key and zone on mount', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ keyId: 'key-b', zone: 'other.org' })
+    );
+
+    const { result } = renderHook(() => useKey(), { wrapper });
+
+    expect(result.current.selectedKey?.id).toBe('key-b');
+    expect(result.current.selectedZone).toBe('other.org');
+  });
+});


### PR DESCRIPTION
## Summary

Makes TSIG key / zone selection predictable and zone-first:

- **Selecting a key keeps your zone** when the new key serves it; the zone clears only when it doesn't. Deselecting the key keeps the zone.
- **Zone-first selection**: the zone dropdown is no longer disabled until a key is picked. Choosing a zone keeps the current key when it serves that zone, otherwise auto-selects the first key that does — no more silent nulling of one selection by the other.
- `availableZones` is documented as the union across all keys; the dead `availableZonesForKey` memo is removed.
- Persisted selections keep the `{keyId, zone}` localStorage shape, now supporting zone-only entries, with restore handling both.

Consumers audited (ZoneEditor, Snapshots, AppContent, AddDNSRecord) — no semantic changes needed.

## Testing

New 8-test suite for the context transition rules and persistence (renderHook + provider pattern). `tsc --noEmit` clean; 149 frontend tests green; eslint clean on touched files.