### PR TITLE
feat(ui): sane first-run and landing experience

### DIFF
--- a/src/components/AppContent.tsx
+++ b/src/components/AppContent.tsx
@@ -1,49 +1,37 @@
 // src/components/AppContent.tsx
 import React, { useEffect, useRef } from 'react';
-import { Routes, Route, useNavigate, useLocation } from 'react-router-dom';
+import { Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
 import Layout from './Layout';
-import AddDNSRecord from './AddDNSRecord';
 import ZoneEditor from './ZoneEditor';
 import Settings from './Settings';
 import Snapshots from './Snapshots';
 import { useKey } from '../context/KeyContext';
 
 function AppContent() {
-  const { selectedKey, selectedZone } = useKey();
+  const { selectedZone } = useKey();
   const navigate = useNavigate();
   const location = useLocation();
-  const isManualNavigation = useRef(false);
+  const prevZoneRef = useRef<string | null>(selectedZone);
 
-  // Auto-navigate to zone editor when a zone is selected from settings
+  // Take the user to the zone editor only at the moment a zone first becomes
+  // selected while they are on the settings page. Later navigation and
+  // zone-to-zone switches are never overridden.
   useEffect(() => {
-    if (selectedZone && selectedKey && location.pathname === '/settings' && !isManualNavigation.current) {
+    const zoneJustSelected = !prevZoneRef.current && Boolean(selectedZone);
+    prevZoneRef.current = selectedZone;
+    if (zoneJustSelected && location.pathname === '/settings') {
       navigate('/zones');
     }
-    isManualNavigation.current = false;
-  }, [selectedZone, selectedKey, navigate, location.pathname]);
-
-  // Track manual navigations to prevent auto-redirect from overriding them
-  useEffect(() => {
-    const handleBeforeNavigate = () => {
-      isManualNavigation.current = true;
-    };
-
-    document.addEventListener('click', handleBeforeNavigate, true);
-    document.addEventListener('keydown', handleBeforeNavigate, true);
-
-    return () => {
-      document.removeEventListener('click', handleBeforeNavigate, true);
-      document.removeEventListener('keydown', handleBeforeNavigate, true);
-    };
-  }, []);
+  }, [selectedZone, navigate, location.pathname]);
 
   return (
     <Layout>
       <Routes>
-        <Route path="/" element={<AddDNSRecord />} />
+        <Route path="/" element={<Navigate to="/zones" replace />} />
         <Route path="/zones" element={<ZoneEditor />} />
         <Route path="/snapshots" element={<Snapshots />} />
         <Route path="/settings" element={<Settings />} />
+        <Route path="*" element={<Navigate to="/zones" replace />} />
       </Routes>
     </Layout>
   );

--- a/src/components/AppContent.tsx
+++ b/src/components/AppContent.tsx
@@ -1,29 +1,17 @@
 // src/components/AppContent.tsx
-import React, { useEffect, useRef } from 'react';
-import { Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import Layout from './Layout';
 import ZoneEditor from './ZoneEditor';
 import Settings from './Settings';
 import Snapshots from './Snapshots';
-import { useKey } from '../context/KeyContext';
 
+// Navigation is always user-initiated. An earlier auto-redirect ("jump to
+// /zones when a zone first becomes selected on /settings") misfired whenever
+// the zone passed through null — key switches on the Settings page and
+// localStorage restores after a refresh both bounced the user out of
+// Settings — so it was removed rather than patched.
 function AppContent() {
-  const { selectedZone } = useKey();
-  const navigate = useNavigate();
-  const location = useLocation();
-  const prevZoneRef = useRef<string | null>(selectedZone);
-
-  // Take the user to the zone editor only at the moment a zone first becomes
-  // selected while they are on the settings page. Later navigation and
-  // zone-to-zone switches are never overridden.
-  useEffect(() => {
-    const zoneJustSelected = !prevZoneRef.current && Boolean(selectedZone);
-    prevZoneRef.current = selectedZone;
-    if (zoneJustSelected && location.pathname === '/settings') {
-      navigate('/zones');
-    }
-  }, [selectedZone, navigate, location.pathname]);
-
   return (
     <Layout>
       <Routes>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -91,8 +91,6 @@ function Layout({ children }: { children: React.ReactNode }) {
 
   const getPageTitle = () => {
     switch (location.pathname) {
-      case '/':
-        return 'Add DNS Record';
       case '/zones':
         return 'Zone Editor';
       case '/snapshots':

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,14 +2,13 @@
 import React from 'react';
 import { List, ListItem, ListItemIcon, ListItemText, Divider, Box, Typography } from '@mui/material';
 import { Link, useLocation } from 'react-router-dom';
-import { Add, Settings, Storage, Backup } from '@mui/icons-material';
+import { Settings, Storage, Backup } from '@mui/icons-material';
 import KeySelector from './KeySelector';
 
 function Navigation() {
   const location = useLocation();
 
   const menuItems = [
-    { text: 'Add DNS Record', icon: <Add />, path: '/' },
     { text: 'Zone Editor', icon: <Storage />, path: '/zones' },
     { text: 'Snapshots', icon: <Backup />, path: '/snapshots' },
     { text: 'Settings', icon: <Settings />, path: '/settings' },

--- a/src/components/ZoneEditor.tsx
+++ b/src/components/ZoneEditor.tsx
@@ -43,6 +43,7 @@ import RedoIcon from '@mui/icons-material/Redo';
 import RecordEditor from './RecordEditor';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { useKey } from '../context/KeyContext';
+import { Link as RouterLink } from 'react-router-dom';
 import { DNSRecord, RecordType } from '../types/dns';
 
 // Sourced from the RecordType enum so the type filter stays in sync with the
@@ -144,7 +145,8 @@ function ZoneEditor() {
   const {
     selectedKey,
     selectedZone,
-    availableZones = []
+    availableZones = [],
+    availableKeys = []
   } = useKey();
 
   const [records, setRecords] = useState<DNSRecord[]>([]);
@@ -482,6 +484,28 @@ function ZoneEditor() {
       rowsPerPage: newRowsPerPage
     });
   };
+
+  // First-run empty state: with no TSIG keys configured there is nothing the
+  // zone editor can do, so point the user at Settings instead of showing a
+  // disabled toolbar and empty table.
+  if (availableKeys.length === 0) {
+    return (
+      <Paper sx={{ p: 3 }}>
+        <Box sx={{ textAlign: 'center', py: 6 }}>
+          <Typography variant="h6" gutterBottom>
+            No TSIG keys configured
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+            Snap DNS uses TSIG keys to authenticate with your DNS servers.
+            Add a key and assign it to your zones to start managing records.
+          </Typography>
+          <Button variant="contained" component={RouterLink} to="/settings">
+            Add a TSIG key to get started
+          </Button>
+        </Box>
+      </Paper>
+    );
+  }
 
   return (
     <Paper sx={{ p: 3 }}>

--- a/src/components/__tests__/ZoneEditor.test.tsx
+++ b/src/components/__tests__/ZoneEditor.test.tsx
@@ -1,0 +1,74 @@
+// src/components/__tests__/ZoneEditor.test.tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ZoneEditor from '../ZoneEditor';
+
+jest.mock('../AddDNSRecord', () => ({ __esModule: true, default: () => null }));
+jest.mock('../RecordEditor', () => ({ __esModule: true, default: () => null }));
+
+jest.mock('../../services/dnsService', () => ({
+  dnsService: {
+    fetchZoneRecords: jest.fn().mockResolvedValue([])
+  }
+}));
+
+jest.mock('../../context/ConfigContext', () => ({
+  useConfig: () => ({ config: { keys: [] }, updateConfig: jest.fn() })
+}));
+
+jest.mock('../../context/PendingChangesContext', () => ({
+  usePendingChanges: () => ({
+    pendingChanges: [],
+    setPendingChanges: jest.fn(),
+    addPendingChange: jest.fn(),
+    setShowPendingDrawer: jest.fn()
+  })
+}));
+
+const mockUseKey = jest.fn();
+jest.mock('../../context/KeyContext', () => ({
+  useKey: () => mockUseKey()
+}));
+
+const renderEditor = () =>
+  render(
+    <MemoryRouter>
+      <ZoneEditor />
+    </MemoryRouter>
+  );
+
+describe('ZoneEditor onboarding states', () => {
+  it('shows the no-keys empty state with a link to settings', () => {
+    mockUseKey.mockReturnValue({
+      selectedKey: null,
+      selectedZone: null,
+      availableZones: [],
+      availableKeys: []
+    });
+
+    renderEditor();
+
+    expect(screen.getByText('No TSIG keys configured')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /add a tsig key to get started/i });
+    expect(link).toHaveAttribute('href', '/settings');
+    // The regular editor chrome is not rendered without keys
+    expect(screen.queryByPlaceholderText('Search records...')).not.toBeInTheDocument();
+  });
+
+  it('prompts for zone selection when keys exist but none is selected', () => {
+    mockUseKey.mockReturnValue({
+      selectedKey: null,
+      selectedZone: null,
+      availableZones: ['example.com'],
+      availableKeys: [
+        { id: 'key-1', name: 'key-1', server: 'ns1.example.com', zones: ['example.com'] }
+      ]
+    });
+
+    renderEditor();
+
+    expect(screen.getByText(/select a zone and tsig key/i)).toBeInTheDocument();
+    expect(screen.queryByText('No TSIG keys configured')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- `/` (and unknown routes) now redirect to `/zones` instead of rendering the standalone Add-DNS-Record page, which was unusable without a key/zone and redundant with ZoneEditor's add-record dialog. The nav entry and the dead `'/'` page title are removed with it.
- **Auto-navigation from Settings is removed entirely.** The original global `click`/`keydown` capture-listener hack was first replaced by a ref-based "zone first becomes selected" rule, but integration review (with the zone-first selection rules from #27 active) showed any such edge detection misfires whenever the zone passes through null: a key switch on Settings followed by picking a zone bounced the user out mid-configuration, and a refresh at `/settings` redirected on boot because the localStorage restore runs after mount. Navigation is now always user-initiated.
- ZoneEditor shows a first-run empty state when no TSIG keys are configured — explains what a key is for and links to Settings — instead of a disabled toolbar over an empty table.

## Testing

New ZoneEditor tests for the no-keys empty state and the keys-but-no-zone alert. `tsc --noEmit` clean; 143 frontend tests green; only pre-existing lint warnings. Cross-branch integration reviewed against #26/#27/#29 (combined tree: 151 tests green).