### PR TITLE
feat(ui): responsive app shell

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,13 +8,18 @@ function Footer() {
     <Box
       component="footer"
       sx={{
-        position: 'fixed',
+        // Fixed bottom-right on desktop; static below the page content on
+        // small screens so it never overlaps scrolled content.
+        position: { xs: 'static', md: 'fixed' },
         bottom: 0,
         right: 0,
         padding: 2,
         display: 'flex',
         alignItems: 'center',
         gap: 1,
+        width: 'fit-content',
+        ml: { xs: 'auto', md: 0 },
+        mt: { xs: 3, md: 0 },
         backgroundColor: 'background.paper',
         borderTopLeftRadius: 8,
         boxShadow: 1,

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,10 +3,13 @@ import React, { useState } from 'react';
 import {
   Box, Typography, IconButton, Divider, Button, Menu, MenuItem, Chip,
   Dialog, DialogTitle, DialogContent, DialogActions, TextField, Alert,
-  CircularProgress,
+  CircularProgress, Drawer,
 } from '@mui/material';
 import { useLocation } from 'react-router-dom';
-import { Brightness4, Brightness7, AccountCircle, Logout, Lock } from '@mui/icons-material';
+import {
+  Brightness4, Brightness7, AccountCircle, Logout, Lock,
+  Menu as MenuIcon,
+} from '@mui/icons-material';
 import Navigation from './Navigation';
 import PendingChangesDrawer from './PendingChangesDrawer';
 import { useConfig } from '../context/ConfigContext';
@@ -22,6 +25,7 @@ function Layout({ children }: { children: React.ReactNode }) {
   const { config } = useConfig();
   const { user, logout } = useAuth();
   const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const [passwordDialogOpen, setPasswordDialogOpen] = useState(false);
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
@@ -111,6 +115,18 @@ function Layout({ children }: { children: React.ReactNode }) {
       bgcolor: 'background.default',
       color: 'text.primary'
     }}>
+      {/* Mobile navigation: temporary drawer toggled by the hamburger button */}
+      <Drawer
+        variant="temporary"
+        open={mobileNavOpen}
+        onClose={() => setMobileNavOpen(false)}
+        ModalProps={{ keepMounted: true }}
+        sx={{ display: { xs: 'block', md: 'none' } }}
+        PaperProps={{ sx: { width: 240 } }}
+      >
+        <Navigation onNavigate={() => setMobileNavOpen(false)} />
+      </Drawer>
+      {/* Desktop navigation: permanent sidebar at md and up */}
       <Box
         component="nav"
         sx={{
@@ -121,27 +137,42 @@ function Layout({ children }: { children: React.ReactNode }) {
           height: '100vh',
           overflow: 'auto',
           position: 'fixed',
-          bgcolor: 'background.paper'
+          bgcolor: 'background.paper',
+          display: { xs: 'none', md: 'block' }
         }}
       >
         <Navigation />
       </Box>
       <Box sx={{
         flexGrow: 1,
-        ml: '240px',
+        minWidth: 0,
+        ml: { xs: 0, md: '240px' },
         p: 3,
-        pb: 8
+        pb: { xs: 3, md: 8 }
       }}>
         <Box sx={{
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
+          flexWrap: 'wrap',
+          gap: 1,
           mb: 3
         }}>
-          <Typography variant="h6">
-            {getPageTitle()}
-          </Typography>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <IconButton
+              color="inherit"
+              aria-label="Open navigation"
+              edge="start"
+              onClick={() => setMobileNavOpen(true)}
+              sx={{ display: { xs: 'inline-flex', md: 'none' } }}
+            >
+              <MenuIcon />
+            </IconButton>
+            <Typography variant="h6">
+              {getPageTitle()}
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 2 }}>
             <Button
               variant="outlined"
               onClick={() => setShowPendingDrawer(true)}
@@ -187,8 +218,9 @@ function Layout({ children }: { children: React.ReactNode }) {
           </Box>
         </Box>
         {children}
+        {/* Fixed at md and up; static below content on small screens */}
+        <Footer />
       </Box>
-      <Footer />
 
       {/* Change Password Dialog */}
       <Dialog open={passwordDialogOpen} onClose={() => setPasswordDialogOpen(false)} maxWidth="xs" fullWidth>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -5,7 +5,12 @@ import { Link, useLocation } from 'react-router-dom';
 import { Add, Settings, Storage, Backup } from '@mui/icons-material';
 import KeySelector from './KeySelector';
 
-function Navigation() {
+interface NavigationProps {
+  // Called after a menu item is clicked, e.g. to close the mobile drawer.
+  onNavigate?: () => void;
+}
+
+function Navigation({ onNavigate }: NavigationProps) {
   const location = useLocation();
 
   const menuItems = [
@@ -38,6 +43,7 @@ function Navigation() {
             key={item.path}
             component={Link}
             to={item.path}
+            onClick={onNavigate}
             selected={location.pathname === item.path}
             sx={{
               color: 'text.primary',

--- a/src/components/PendingChangesDrawer.tsx
+++ b/src/components/PendingChangesDrawer.tsx
@@ -310,7 +310,7 @@ function PendingChangesDrawer({
       // any per-zone failures stay visible.
       onClose={applying ? undefined : onClose}
       PaperProps={{
-        sx: { width: 400 }
+        sx: { width: { xs: '100vw', sm: 400 } }
       }}
     >
       <Box sx={{ p: 2 }}>

--- a/src/components/ZoneEditor.tsx
+++ b/src/components/ZoneEditor.tsx
@@ -498,6 +498,9 @@ function ZoneEditor() {
       )}
       <Box sx={{
         display: 'flex',
+        // Wrap on small screens so the search, type filter, and refresh
+        // controls stack instead of forcing horizontal overflow.
+        flexWrap: { xs: 'wrap', md: 'nowrap' },
         gap: 2,
         mb: 3,
         p: 2,


### PR DESCRIPTION
## Summary

Makes the shell usable on narrow screens; at `md` and up rendering is pixel-identical to before.

- Below `md`: the permanent 240px sidebar becomes a temporary drawer toggled by a hamburger in the header row; content margin drops to 0; nav items close the drawer on click.
- Footer is static (in-flow) on small screens so it can't overlap content; desktop keeps the fixed bottom-right placement.
- PendingChangesDrawer width is `100vw` on xs (400px from sm up); the ZoneEditor toolbar wraps below `md`.

## Testing

`tsc --noEmit` clean; 141 frontend tests green; eslint warnings identical to main (stash-compared).