### PR TITLE
fix(ui): consistent success/error surfacing via global toasts

### DIFF
--- a/src/components/AddDNSRecord.tsx
+++ b/src/components/AddDNSRecord.tsx
@@ -275,7 +275,6 @@ function AddDNSRecord({ zone, onSuccess, onClose }: AddDNSRecordProps) {
   const [fieldErrors, setFieldErrors] = useState<Record<string, string | null>>({});
   const [validationErrors, setValidationErrors] = useState<Record<string, string | null>>({});
   const [submitting, setSubmitting] = useState(false);
-  const [success, setSuccess] = useState<string | null>(null);
   const [ptrPreview, setPtrPreview] = useState('');
   const [txtSubtype, setTxtSubtype] = useState<TxtSubtype | null>(null);
   const [validationWarnings, setValidationWarnings] = useState<string[]>([]);
@@ -492,7 +491,6 @@ function AddDNSRecord({ zone, onSuccess, onClose }: AddDNSRecordProps) {
     event.preventDefault();
     setSubmitting(true);
     setError(null);
-    setSuccess(null);
 
     try {
       if (!validateFields()) {
@@ -716,12 +714,6 @@ function AddDNSRecord({ zone, onSuccess, onClose }: AddDNSRecordProps) {
           sx={{ mt: 2 }}
         >
           {typeof error === 'string' ? error : error.message}
-        </Alert>
-      )}
-
-      {success && (
-        <Alert severity="success" sx={{ mt: 2 }}>
-          {success}
         </Alert>
       )}
 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -36,6 +36,7 @@ import UserManagement from './UserManagement';
 import SSOConfiguration from './SSOConfiguration';
 import AuditLog from './AuditLog';
 import { useAuth } from '../context/AuthContext';
+import { useNotification } from '../context/NotificationContext';
 import { Config, ensureValidConfig, WebhookProvider } from '../types/config';
 import { Key } from '../types/keys';
 import { backupService } from '../services/backupService';
@@ -143,6 +144,7 @@ function a11yProps(index: number) {
 function Settings() {
   const { config, updateConfig } = useConfig();
   const { user } = useAuth();
+  const { showSuccess, showError } = useNotification();
   const [currentTab, setCurrentTab] = useState(0);
   const [defaultTTL, setDefaultTTL] = useState(config.defaultTTL);
   const [webhookUrl, setWebhookUrl] = useState(config.webhookUrl || '');
@@ -150,8 +152,6 @@ function Settings() {
     config.webhookProvider || 'mattermost'
   );
   const [saving, setSaving] = useState(false);
-  const [success, setSuccess] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
   const [testing, setTesting] = useState(false);
   const [exportDialogOpen, setExportDialogOpen] = useState(false);
   const [exportKeys, setExportKeys] = useState(false);
@@ -161,6 +161,7 @@ function Settings() {
   const [importedData, setImportedData] = useState<ImportData | null>(null);
   const [selectedKeyId, setSelectedKeyId] = useState('');
   const [importType, setImportType] = useState<'full' | 'zones' | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
   const [exportBackups, setExportBackups] = useState(true);
 
   const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
@@ -169,8 +170,7 @@ function Settings() {
 
   const handleSave = async () => {
     setSaving(true);
-    setError(null);
-    
+
     try {
       const updatedConfig = {
         ...config,
@@ -181,10 +181,10 @@ function Settings() {
       
       await updateConfig(updatedConfig);
       notificationService.setWebhookConfig(webhookUrl, webhookProvider);
-      setSuccess('Settings saved successfully');
+      showSuccess('Settings saved successfully');
     } catch (err: unknown) {
       const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
-      setError(`Failed to save settings: ${errorMessage}`);
+      showError(`Failed to save settings: ${errorMessage}`);
     } finally {
       setSaving(false);
     }
@@ -192,13 +192,12 @@ function Settings() {
 
   const handleTestWebhook = async () => {
     setTesting(true);
-    setError(null);
     try {
       await notificationService.testWebhook();
-      setSuccess('Test notification sent successfully!');
+      showSuccess('Test notification sent successfully!');
     } catch (err: unknown) {
       const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
-      setError(`Failed to send test notification: ${errorMessage}`);
+      showError(`Failed to send test notification: ${errorMessage}`);
     } finally {
       setTesting(false);
     }
@@ -283,9 +282,9 @@ function Settings() {
       document.body.removeChild(a);
 
       setExportDialogOpen(false);
-      setSuccess('Configuration exported successfully');
+      showSuccess('Configuration exported successfully');
     } catch (error) {
-      setError(`Failed to export configuration: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      showError(`Failed to export configuration: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   };
 
@@ -310,15 +309,24 @@ function Settings() {
 
         setImportType(isZonesOnly ? 'zones' : 'full');
         setImportedData(data);
+        setImportError(null);
         setImportDialogOpen(true);
       } catch (error) {
-        setError(`Failed to read import file: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        showError(`Failed to read import file: ${error instanceof Error ? error.message : 'Unknown error'}`);
       }
     };
     reader.readAsText(file);
   };
 
   const handleImportConfirm = async () => {
+    // Dialog-level form validation: a zones-only import needs a target key
+    // before anything can run, so surface this inline rather than as a toast.
+    if (importType === 'zones' && !selectedKeyId) {
+      setImportError('Please select a key to associate with the imported zones');
+      return;
+    }
+    setImportError(null);
+
     try {
       if (!importedData?.dns_manager_config) {
         throw new Error('Invalid import data');
@@ -326,10 +334,6 @@ function Settings() {
 
       if (importType === 'zones') {
         // Handle zones-only import
-        if (!selectedKeyId) {
-          throw new Error('Please select a key to associate with the imported zones');
-        }
-
         const currentConfig = ensureValidConfig(
           JSON.parse(localStorage.getItem('dns_manager_config') || '{}')
         );
@@ -350,7 +354,7 @@ function Settings() {
 
         // Update config
         await updateConfig(ensureValidConfig(currentConfig));
-        setSuccess('Zones imported successfully');
+        showSuccess('Zones imported successfully');
       } else {
         // Handle full backup import
         const currentConfig = JSON.parse(localStorage.getItem('dns_manager_config') || '{}');
@@ -380,14 +384,14 @@ function Settings() {
           localStorage.setItem('dnsBackups', JSON.stringify(backups));
         }
 
-        setSuccess('Configuration and backups imported successfully');
+        showSuccess('Configuration and backups imported successfully');
       }
 
       setImportDialogOpen(false);
       setImportedData(null);
       setSelectedKeyId('');
     } catch (error) {
-      setError(`Failed to import configuration: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      showError(`Failed to import configuration: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   };
 
@@ -486,18 +490,6 @@ function Settings() {
             </Select>
             <FormHelperText>Default number of records to show per page in tables</FormHelperText>
           </FormControl>
-
-          {success && (
-            <Alert severity="success" onClose={() => setSuccess(null)}>
-              {success}
-            </Alert>
-          )}
-
-          {error && (
-            <Alert severity="error" onClose={() => setError(null)}>
-              {error}
-            </Alert>
-          )}
 
           <Stack direction="row" spacing={2}>
             <Button
@@ -655,10 +647,18 @@ function Settings() {
       {/* Import Dialog */}
       <Dialog
         open={importDialogOpen}
-        onClose={() => setImportDialogOpen(false)}
+        onClose={() => {
+          setImportDialogOpen(false);
+          setImportError(null);
+        }}
       >
         <DialogTitle>Import Configuration</DialogTitle>
         <DialogContent>
+          {importError && (
+            <Alert severity="error" onClose={() => setImportError(null)} sx={{ mb: 2 }}>
+              {importError}
+            </Alert>
+          )}
           <DialogContentText>
             {importType === 'zones' ? (
               <>
@@ -669,7 +669,10 @@ function Settings() {
                   <InputLabel>Select Key</InputLabel>
                   <Select
                     value={selectedKeyId}
-                    onChange={(e) => setSelectedKeyId(e.target.value)}
+                    onChange={(e) => {
+                      setSelectedKeyId(e.target.value);
+                      setImportError(null);
+                    }}
                     label="Select Key"
                   >
                     {config.keys?.map((key: Key) => (
@@ -686,7 +689,14 @@ function Settings() {
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setImportDialogOpen(false)}>Cancel</Button>
+          <Button
+            onClick={() => {
+              setImportDialogOpen(false);
+              setImportError(null);
+            }}
+          >
+            Cancel
+          </Button>
           <Button onClick={handleImportConfirm} variant="contained">
             Import
           </Button>

--- a/src/components/TSIGKeyManagement.tsx
+++ b/src/components/TSIGKeyManagement.tsx
@@ -31,13 +31,15 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import KeyIcon from '@mui/icons-material/Key';
 import { tsigKeyService, TSIGKey, TSIGKeyCreate } from '../services/tsigKeyService';
 import { useAuth } from '../context/AuthContext';
+import { useNotification } from '../context/NotificationContext';
 
 export default function TSIGKeyManagement() {
   const { user } = useAuth();
+  const { showSuccess, showError } = useNotification();
   const [keys, setKeys] = useState<TSIGKey[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const [success, setSuccess] = useState('');
+  const [formError, setFormError] = useState('');
   const [dialogOpen, setDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [editingKey, setEditingKey] = useState<TSIGKey | null>(null);
@@ -93,11 +95,13 @@ export default function TSIGKeyManagement() {
         zones: [],
       });
     }
+    setFormError('');
     setDialogOpen(true);
   };
 
   const handleCloseDialog = () => {
     setDialogOpen(false);
+    setFormError('');
     setEditingKey(null);
     setFormData({
       name: '',
@@ -130,17 +134,16 @@ export default function TSIGKeyManagement() {
 
   const handleSubmit = async () => {
     try {
-      setError('');
-      setSuccess('');
+      setFormError('');
 
       // Validate required fields
       if (!formData.name || !formData.server || !formData.keyName || !formData.algorithm) {
-        setError('Please fill in all required fields');
+        setFormError('Please fill in all required fields');
         return;
       }
 
       if (!editingKey && !formData.keyValue) {
-        setError('Key value is required when creating a new key');
+        setFormError('Key value is required when creating a new key');
         return;
       }
 
@@ -158,17 +161,17 @@ export default function TSIGKeyManagement() {
           updates.keyValue = formData.keyValue;
         }
         await tsigKeyService.updateKey(editingKey.id, updates);
-        setSuccess('Key updated successfully');
+        showSuccess('Key updated successfully');
       } else {
         // Create new key
         await tsigKeyService.createKey(formData);
-        setSuccess('Key created successfully');
+        showSuccess('Key created successfully');
       }
 
       handleCloseDialog();
       loadKeys();
     } catch (err: any) {
-      setError(err.message || 'Failed to save key');
+      showError(err.message || 'Failed to save key');
     }
   };
 
@@ -176,15 +179,13 @@ export default function TSIGKeyManagement() {
     if (!keyToDelete) return;
 
     try {
-      setError('');
-      setSuccess('');
       await tsigKeyService.deleteKey(keyToDelete.id);
-      setSuccess('Key deleted successfully');
+      showSuccess('Key deleted successfully');
       setDeleteDialogOpen(false);
       setKeyToDelete(null);
       loadKeys();
     } catch (err: any) {
-      setError(err.message || 'Failed to delete key');
+      showError(err.message || 'Failed to delete key');
     }
   };
 
@@ -220,12 +221,6 @@ export default function TSIGKeyManagement() {
       {error && (
         <Alert severity="error" onClose={() => setError('')} sx={{ mb: 2 }}>
           {error}
-        </Alert>
-      )}
-
-      {success && (
-        <Alert severity="success" onClose={() => setSuccess('')} sx={{ mb: 2 }}>
-          {success}
         </Alert>
       )}
 
@@ -311,6 +306,11 @@ export default function TSIGKeyManagement() {
           {editingKey ? 'Edit TSIG Key' : 'Add TSIG Key'}
         </DialogTitle>
         <DialogContent>
+          {formError && (
+            <Alert severity="error" onClose={() => setFormError('')} sx={{ mt: 1 }}>
+              {formError}
+            </Alert>
+          )}
           <Box display="flex" flexDirection="column" gap={2} mt={1}>
             <TextField
               label="Key Name (Display Name)"

--- a/src/components/ZoneEditor.tsx
+++ b/src/components/ZoneEditor.tsx
@@ -43,6 +43,7 @@ import RedoIcon from '@mui/icons-material/Redo';
 import RecordEditor from './RecordEditor';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { useKey } from '../context/KeyContext';
+import { useNotification } from '../context/NotificationContext';
 import { Link as RouterLink } from 'react-router-dom';
 import { DNSRecord, RecordType } from '../types/dns';
 
@@ -149,6 +150,8 @@ function ZoneEditor() {
     availableKeys = []
   } = useKey();
 
+  const { showError } = useNotification();
+
   const [records, setRecords] = useState<DNSRecord[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
@@ -248,7 +251,7 @@ function ZoneEditor() {
       setEditDialogOpen(false);
       setEditingRecord(null);
     } catch (error) {
-      setError(`Failed to delete record: ${(error as Error).message}`);
+      showError(`Failed to delete record: ${(error as Error).message}`);
     }
   };
 
@@ -275,7 +278,7 @@ function ZoneEditor() {
       setEditDialogOpen(false);
       setEditingRecord(null);
     } catch (error) {
-      setError(`Failed to delete records: ${(error as Error).message}`);
+      showError(`Failed to delete records: ${(error as Error).message}`);
     }
   };
 
@@ -301,7 +304,7 @@ function ZoneEditor() {
       setCopyDialogOpen(false);
       setCopyingRecord(null);
     } catch (error) {
-      setError((error as Error).message);
+      showError(`Failed to update record: ${(error as Error).message}`);
     }
   };
 
@@ -442,7 +445,7 @@ function ZoneEditor() {
             await loadZoneRecords();
           } catch (error) {
             console.error('Error refreshing zone records:', error);
-            setError('Failed to refresh zone records after changes');
+            showError('Failed to refresh zone records after changes');
           } finally {
             setIsRefreshing(false);
           }
@@ -452,7 +455,7 @@ function ZoneEditor() {
 
     window.addEventListener('dnsChangesApplied', handleChangesApplied);
     return () => window.removeEventListener('dnsChangesApplied', handleChangesApplied);
-  }, [selectedZone, loadZoneRecords]);
+  }, [selectedZone, loadZoneRecords, showError]);
 
   const handleCopyRecord = (record: DNSRecord) => {
     setCopyingRecord({

--- a/src/components/__tests__/ZoneEditor.test.tsx
+++ b/src/components/__tests__/ZoneEditor.test.tsx
@@ -26,6 +26,16 @@ jest.mock('../../context/PendingChangesContext', () => ({
   })
 }));
 
+jest.mock('../../context/NotificationContext', () => ({
+  useNotification: () => ({
+    showNotification: jest.fn(),
+    showSuccess: jest.fn(),
+    showError: jest.fn(),
+    showInfo: jest.fn(),
+    showWarning: jest.fn()
+  })
+}));
+
 const mockUseKey = jest.fn();
 jest.mock('../../context/KeyContext', () => ({
   useKey: () => mockUseKey()


### PR DESCRIPTION
## Summary

One policy applied across the frontend: transient operation outcomes (save/delete/test/import succeeded or failed) surface as global toasts; form validation and persistent context (load failures, selection guidance) stay inline.

- **TSIGKeyManagement**: create/update/delete outcomes → toasts. Dialog required-field validation now renders inside the dialog (it previously rendered on the page behind the open modal). Key-list load failure stays inline.
- **Settings**: saved/test-webhook/export/import outcomes → toasts; import-dialog validation gets its own in-dialog Alert (same behind-the-modal fix).
- **ZoneEditor**: change-queueing failures and post-apply refresh failure → toasts; AXFR load failure, selection guidance, and refresh progress stay inline.
- **AddDNSRecord**: validation stays inline per policy; removed a dead `success` state that could never render.

**Deliberately excluded: `Snapshots.tsx`** — it's being rewritten on the parallel server-side-snapshots branch. The equivalent conversions for it are documented below to apply after that merges:

<details><summary>Deferred Snapshots.tsx conversions</summary>

- `handleBackup`, `handleImportSnapshot`, `confirmDeleteBackup`, `handleDownloadBackup`, `handleRestoreBackup`, `handleCompareBackup`, `confirmRestore` outcomes → showSuccess/showError/showInfo.
- Keep inline: snapshots load failure, "select zone and key" and "select a file" validations (import-dialog validation should get its own local state — the shared error state currently renders both at page level and inside the import dialog).
- Then remove the page-level success Alert.
</details>

## Testing

`tsc --noEmit` clean; 151/151 tests green (ZoneEditor tests gained a NotificationContext mock; no assertions weakened); lint warnings identical to main (stash-compared).