### PR TITLE
fix(security): dev CORS allowlist and webhook URL log redaction

### DIFF
--- a/backend/src/middleware/__tests__/corsOrigin.test.ts
+++ b/backend/src/middleware/__tests__/corsOrigin.test.ts
@@ -1,0 +1,63 @@
+// backend/src/middleware/__tests__/corsOrigin.test.ts
+import { DEV_DEFAULT_ORIGINS, getAllowedOrigins, isOriginAllowed } from '../corsOrigin';
+
+describe('getAllowedOrigins', () => {
+  it('returns only ALLOWED_ORIGINS entries in production', () => {
+    expect(getAllowedOrigins('production', 'https://dns.example.com,https://dns2.example.com'))
+      .toEqual(['https://dns.example.com', 'https://dns2.example.com']);
+  });
+
+  it('returns an empty list in production when ALLOWED_ORIGINS is unset', () => {
+    expect(getAllowedOrigins('production', undefined)).toEqual([]);
+  });
+
+  it('does not include dev defaults in production', () => {
+    expect(getAllowedOrigins('production', 'https://dns.example.com'))
+      .not.toContain('http://localhost:3000');
+  });
+
+  it('returns the known dev origins in development', () => {
+    const origins = getAllowedOrigins('development', undefined);
+    DEV_DEFAULT_ORIGINS.forEach(origin => expect(origins).toContain(origin));
+  });
+
+  it('merges ALLOWED_ORIGINS with dev defaults in development', () => {
+    const origins = getAllowedOrigins('development', 'http://10.100.0.30:3001');
+    expect(origins).toContain('http://10.100.0.30:3001');
+    expect(origins).toContain('http://localhost:3000');
+  });
+
+  it('deduplicates ALLOWED_ORIGINS entries that repeat dev defaults', () => {
+    const origins = getAllowedOrigins('development', 'http://localhost:3000');
+    expect(origins.filter(o => o === 'http://localhost:3000')).toHaveLength(1);
+  });
+
+  it('treats test environment like development', () => {
+    expect(getAllowedOrigins('test', undefined)).toEqual([...DEV_DEFAULT_ORIGINS]);
+  });
+});
+
+describe('isOriginAllowed', () => {
+  const allowed = getAllowedOrigins('development', undefined);
+
+  it('allows requests without an Origin header', () => {
+    expect(isOriginAllowed(undefined, allowed)).toBe(true);
+    expect(isOriginAllowed(undefined, [])).toBe(true);
+  });
+
+  it('allows listed origins', () => {
+    expect(isOriginAllowed('http://localhost:3000', allowed)).toBe(true);
+    expect(isOriginAllowed('http://localhost:3001', allowed)).toBe(true);
+    expect(isOriginAllowed('http://frontend:3001', allowed)).toBe(true);
+  });
+
+  it('rejects unlisted origins in development', () => {
+    expect(isOriginAllowed('http://evil.example.com', allowed)).toBe(false);
+    expect(isOriginAllowed('http://localhost:9999', allowed)).toBe(false);
+  });
+
+  it('requires an exact match (no prefix or scheme laxness)', () => {
+    expect(isOriginAllowed('https://localhost:3000', allowed)).toBe(false);
+    expect(isOriginAllowed('http://localhost:3000.evil.com', allowed)).toBe(false);
+  });
+});

--- a/backend/src/middleware/corsOrigin.ts
+++ b/backend/src/middleware/corsOrigin.ts
@@ -1,0 +1,29 @@
+// backend/src/middleware/corsOrigin.ts
+// Origin allowlist logic for CORS, extracted from server.ts so it can be unit tested.
+
+// Known development origins: CRA default (3000), the docker-compose dev/test
+// frontend port (3001), and the container-internal frontend hostname.
+export const DEV_DEFAULT_ORIGINS: readonly string[] = [
+  'http://localhost:3000',
+  'http://localhost:3001',
+  'http://127.0.0.1:3000',
+  'http://127.0.0.1:3001',
+  'http://frontend:3001'
+];
+
+// Builds the effective origin allowlist for the given environment.
+// Production uses ALLOWED_ORIGINS exclusively; development/test get the known
+// dev origins plus anything in ALLOWED_ORIGINS.
+export function getAllowedOrigins(nodeEnv: string, allowedOriginsEnv?: string): string[] {
+  const fromEnv = allowedOriginsEnv?.split(',') || [];
+  if (nodeEnv === 'production') {
+    return fromEnv;
+  }
+  return [...new Set([...DEV_DEFAULT_ORIGINS, ...fromEnv])];
+}
+
+// Requests without an Origin header (curl, same-origin, server-to-server) are
+// allowed; browser cross-origin requests must match the allowlist exactly.
+export function isOriginAllowed(origin: string | undefined, allowedOrigins: string[]): boolean {
+  return !origin || allowedOrigins.includes(origin);
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import session from 'express-session';
 import FileStore from 'session-file-store';
 import { requestLogger } from './middleware/logging';
+import { getAllowedOrigins, isOriginAllowed } from './middleware/corsOrigin';
 import { generalApiLimiter } from './middleware/rateLimiter';
 import { userService } from './services/userService';
 import { tsigKeyService } from './services/tsigKeyService';
@@ -51,24 +52,21 @@ const sessionStore = new SessionFileStore({
   retries: 0
 });
 
-// CORS configuration
+// CORS configuration: production uses ALLOWED_ORIGINS exclusively;
+// development/test use the known dev origins plus ALLOWED_ORIGINS.
+const allowedOrigins = getAllowedOrigins(NODE_ENV, process.env.ALLOWED_ORIGINS);
 const corsOptions = {
   origin: (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
-    // In test/development, allow all origins
-    if (NODE_ENV === 'test' || NODE_ENV === 'development') {
+    if (isOriginAllowed(origin, allowedOrigins)) {
       callback(null, true);
       return;
     }
-
-    // Production: strict CORS
-    const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',') || [];
-
-    if (!origin || allowedOrigins.includes(origin)) {
-      callback(null, true);
-    } else {
+    if (NODE_ENV === 'production') {
       console.warn(`Rejected CORS request from origin: ${origin}`);
-      callback(new Error(`CORS not allowed for origin: ${origin}`));
+    } else {
+      console.warn(`CORS: rejected ${NODE_ENV}-mode request from origin ${origin}; allowed origins are [${allowedOrigins.join(', ')}] - set ALLOWED_ORIGINS to add yours`);
     }
+    callback(new Error(`CORS not allowed for origin: ${origin}`));
   },
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH'],

--- a/backend/src/services/webhookService.ts
+++ b/backend/src/services/webhookService.ts
@@ -252,8 +252,9 @@ class WebhookService {
     try {
       const formattedPayload = this.formatPayload(config.provider, payload);
 
+      // Webhook URLs embed secret tokens (Slack/Discord/Teams/Mattermost) - never log them.
       console.log('Sending webhook request:', {
-        url: config.url,
+        url: '[REDACTED]',
         provider: config.provider,
         payload: formattedPayload
       });


### PR DESCRIPTION
## Summary

Two scoped hygiene items from the known-issues list:

- **Dev-mode CORS no longer allows all origins.** Development/test now use a known-origins allowlist (CRA localhost:3000, compose frontend :3001, 127.0.0.1 variants, container-internal `http://frontend:3001`) merged with `ALLOWED_ORIGINS` when set. Production behavior is unchanged (`ALLOWED_ORIGINS` exclusively). Rejections in dev log a loud one-liner naming the origin, the full allowlist, and how to extend it. The origin logic is extracted to `backend/src/middleware/corsOrigin.ts` so it's unit-testable (11 new tests).
- **Log audit across the backend (~144 console statements swept):** one real leak found and fixed — the webhook send log printed the webhook URL, and Slack/Discord/Teams/Mattermost URLs embed secret tokens; now `[REDACTED]`. Everything else key/auth/session-adjacent was verified clean (TSIG secrets go via 0600 keyfile and never hit argv or logs; no password/session/header logging), with findings documented in the audit.

## Testing

Backend: lint 0 errors, 105/105 tests (9 suites, including the new corsOrigin suite), build clean.