### PR TITLE
fix(auth): refresh session privileges from user store per request

### DIFF
--- a/backend/src/middleware/__tests__/auth.test.ts
+++ b/backend/src/middleware/__tests__/auth.test.ts
@@ -1,0 +1,280 @@
+// backend/src/middleware/__tests__/auth.test.ts
+import { Request, Response, NextFunction } from 'express';
+import { requireAuth, requireRole, requireWriteAccess } from '../auth';
+import { AuthenticatedRequest, User, UserRole } from '../../types/auth';
+import { userService } from '../../services/userService';
+
+jest.mock('../../services/userService', () => ({
+  userService: {
+    getUserById: jest.fn(),
+  },
+}));
+
+const mockGetUserById = userService.getUserById as jest.MockedFunction<typeof userService.getUserById>;
+
+type SessionLike = {
+  userId?: string;
+  username?: string;
+  role?: UserRole;
+  allowedKeyIds?: string[];
+  allowedZones?: string[];
+  destroy?: (cb: (err?: unknown) => void) => void;
+};
+
+interface MockRes {
+  statusCode?: number;
+  body?: unknown;
+  status: jest.Mock;
+  json: jest.Mock;
+}
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'user_1',
+    username: 'alice',
+    passwordHash: 'hash',
+    role: UserRole.ADMIN,
+    createdAt: new Date(),
+    allowedKeyIds: ['key-a', 'key-b'],
+    allowedZones: ['example.com'],
+    ...overrides,
+  };
+}
+
+function makeReq(session: SessionLike | undefined): Request {
+  return { session } as unknown as Request;
+}
+
+function makeRes(): Response & MockRes {
+  const res = {} as Response & MockRes;
+  res.status = jest.fn((code: number) => {
+    res.statusCode = code;
+    return res;
+  });
+  res.json = jest.fn((payload: unknown) => {
+    res.body = payload;
+    return res;
+  });
+  return res;
+}
+
+function userOf(req: Request) {
+  return (req as AuthenticatedRequest).user;
+}
+
+describe('requireAuth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects with 401 when there is no session', async () => {
+    const req = makeReq(undefined);
+    const res = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.body).toMatchObject({ code: 'NOT_AUTHENTICATED' });
+    expect(next).not.toHaveBeenCalled();
+    expect(mockGetUserById).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 401 when the session has no userId', async () => {
+    const req = makeReq({ username: 'alice' });
+    const res = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('populates req.user from fresh DB values, keeping identity from the session', async () => {
+    mockGetUserById.mockResolvedValue(
+      makeUser({ role: UserRole.EDITOR, allowedKeyIds: ['key-x'], allowedZones: ['db.zone'] })
+    );
+    const req = makeReq({
+      userId: 'user_1',
+      username: 'alice',
+      // Stale session values that must be ignored:
+      role: UserRole.ADMIN,
+      allowedKeyIds: ['stale-key'],
+      allowedZones: ['stale.zone'],
+    });
+    const res = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(mockGetUserById).toHaveBeenCalledWith('user_1');
+    const user = userOf(req);
+    expect(user).toBeDefined();
+    expect(user?.userId).toBe('user_1');
+    expect(user?.username).toBe('alice');
+    expect(user?.role).toBe(UserRole.EDITOR);
+    expect(user?.allowedKeyIds).toEqual(['key-x']);
+    expect(user?.allowedZones).toEqual(['db.zone']);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('reflects a role change on the next request without re-login', async () => {
+    // User logged in as admin (session role), but has since been demoted to viewer.
+    mockGetUserById.mockResolvedValue(makeUser({ role: UserRole.VIEWER }));
+    const req = makeReq({ userId: 'user_1', username: 'alice', role: UserRole.ADMIN });
+    const res = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(userOf(req)?.role).toBe(UserRole.VIEWER);
+
+    // Downstream authorization now sees the fresh viewer role.
+    const writeRes = makeRes();
+    const writeNext = jest.fn() as NextFunction;
+    requireWriteAccess(req, writeRes, writeNext);
+    expect(writeRes.status).toHaveBeenCalledWith(403);
+    expect(writeRes.body).toMatchObject({ code: 'READ_ONLY' });
+    expect(writeNext).not.toHaveBeenCalled();
+
+    const roleRes = makeRes();
+    const roleNext = jest.fn() as NextFunction;
+    requireRole(UserRole.ADMIN)(req, roleRes, roleNext);
+    expect(roleRes.status).toHaveBeenCalledWith(403);
+    expect(roleRes.body).toMatchObject({ code: 'FORBIDDEN' });
+    expect(roleNext).not.toHaveBeenCalled();
+  });
+
+  it('reflects an allowedKeyIds revocation on the next request', async () => {
+    mockGetUserById.mockResolvedValue(
+      makeUser({ role: UserRole.EDITOR, allowedKeyIds: [] })
+    );
+    const req = makeReq({
+      userId: 'user_1',
+      username: 'alice',
+      role: UserRole.EDITOR,
+      allowedKeyIds: ['key-a', 'key-b'],
+    });
+    const res = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(userOf(req)?.allowedKeyIds).toEqual([]);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys the session and returns 401 when the user no longer exists', async () => {
+    mockGetUserById.mockResolvedValue(null);
+    const destroy = jest.fn((cb: (err?: unknown) => void) => cb());
+    const req = makeReq({ userId: 'deleted_user', username: 'ghost', destroy });
+    const res = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.body).toMatchObject({ code: 'NOT_AUTHENTICATED' });
+    expect(next).not.toHaveBeenCalled();
+    expect(userOf(req)).toBeUndefined();
+  });
+
+  it('defaults allowedZones to an empty array when the stored user has none', async () => {
+    mockGetUserById.mockResolvedValue(
+      makeUser({ allowedZones: undefined as unknown as string[] })
+    );
+    const req = makeReq({ userId: 'user_1', username: 'alice' });
+    const res = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(userOf(req)?.allowedZones).toEqual([]);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards unexpected lookup errors to next', async () => {
+    const boom = new Error('store failure');
+    mockGetUserById.mockRejectedValue(boom);
+    const req = makeReq({ userId: 'user_1', username: 'alice' });
+    const res = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(boom);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});
+
+describe('requireRole', () => {
+  it('rejects with 401 when req.user is missing', () => {
+    const req = {} as Request;
+    const res = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    requireRole(UserRole.ADMIN)(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows a user whose role is in the allowed set', () => {
+    const req = {} as AuthenticatedRequest;
+    req.user = {
+      userId: 'user_1',
+      username: 'alice',
+      role: UserRole.ADMIN,
+      allowedKeyIds: [],
+      allowedZones: [],
+    };
+    const res = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    requireRole(UserRole.ADMIN, UserRole.EDITOR)(req as Request, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});
+
+describe('requireWriteAccess', () => {
+  it('rejects viewers with 403 READ_ONLY', () => {
+    const req = {} as AuthenticatedRequest;
+    req.user = {
+      userId: 'user_1',
+      username: 'alice',
+      role: UserRole.VIEWER,
+      allowedKeyIds: [],
+      allowedZones: [],
+    };
+    const res = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    requireWriteAccess(req as Request, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.body).toMatchObject({ code: 'READ_ONLY' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows editors to proceed', () => {
+    const req = {} as AuthenticatedRequest;
+    req.user = {
+      userId: 'user_1',
+      username: 'alice',
+      role: UserRole.EDITOR,
+      allowedKeyIds: [],
+      allowedZones: [],
+    };
+    const res = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    requireWriteAccess(req as Request, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,11 +1,19 @@
 // backend/src/middleware/auth.ts
 import { Request, Response, NextFunction } from 'express';
 import { AuthenticatedRequest, UserRole } from '../types/auth';
+import { userService } from '../services/userService';
 
 /**
- * Middleware to check if user is authenticated
+ * Middleware to check if user is authenticated.
+ *
+ * Privileges (role/allowedKeyIds/allowedZones) are re-loaded from the user
+ * store on every request rather than trusted from the login-time session copy.
+ * This ensures role demotions, key/zone-allowlist revocations, and account
+ * deletions take effect immediately instead of only after the session expires
+ * or the user re-authenticates. Identity (userId/username) is stable and is
+ * kept from the session.
  */
-export function requireAuth(req: Request, res: Response, next: NextFunction): void {
+export async function requireAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
   const authReq = req as AuthenticatedRequest;
 
   if (!req.session || !req.session.userId) {
@@ -17,16 +25,36 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
     return;
   }
 
-  // Attach user data to request
-  authReq.user = {
-    userId: req.session.userId!,
-    username: req.session.username!,
-    role: req.session.role!,
-    allowedKeyIds: req.session.allowedKeyIds!,
-    allowedZones: req.session.allowedZones || [],
-  };
+  try {
+    // Re-load current privileges from the user store (in-memory, cheap).
+    const dbUser = await userService.getUserById(req.session.userId);
 
-  next();
+    if (!dbUser) {
+      // User was deleted mid-session: destroy the session so it stops working
+      // immediately, then reject.
+      req.session.destroy(() => {
+        res.status(401).json({
+          success: false,
+          error: 'Authentication required',
+          code: 'NOT_AUTHENTICATED'
+        });
+      });
+      return;
+    }
+
+    // Identity comes from the session; privileges come from the database.
+    authReq.user = {
+      userId: req.session.userId,
+      username: req.session.username || dbUser.username,
+      role: dbUser.role,
+      allowedKeyIds: dbUser.allowedKeyIds,
+      allowedZones: dbUser.allowedZones || [],
+    };
+
+    next();
+  } catch (err) {
+    next(err);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Confirmed authz finding: `requireAuth` rebuilt `req.user.role` and `allowedKeyIds` from the login-time session, so demoting a user or revoking their key/zone grants had no effect until the 24h session expired or they re-logged-in — a rogue or compromised account couldn't be locked out. (`allowedZones` was already DB-fresh via `checkZoneAccess`; this brings role and key grants to the same freshness.)

`requireAuth` is now async and re-loads role/allowedKeyIds/allowedZones from `userService.getUserById` on every authenticated request (an in-memory Map lookup, cheap). Identity (userId/username) is kept from the session. If the user was deleted mid-session, the session is destroyed and the request rejected 401 — the stale session stops working on the next request, not at TTL. `requireRole`/`requireWriteAccess` read the now-fresh role transparently.

Scope kept to `middleware/auth.ts` only (coordinating with the parallel `fix/auth-hardening` branch). `checkZoneAccess` is left as-is and still correct; a future cleanup could have it read the now-fresh `req.user.allowedZones` to drop one redundant lookup — noted, not done here.

## Testing

12 new middleware tests (role demotion reflected next request, key revocation reflected, deleted-user → session destroyed + 401, DB overrides stale session, error forwarding). Backend 193 tests green; lint 0 warnings on the touched files; build clean.