### PR TITLE
fix(security): harden auth layer (SSRF, prod secrets, session fixation, backup gate)

### DIFF
--- a/backend/src/config/__tests__/secrets.test.ts
+++ b/backend/src/config/__tests__/secrets.test.ts
@@ -1,0 +1,61 @@
+// backend/src/config/__tests__/secrets.test.ts
+import {
+  requireSecret,
+  resolveSessionSecret,
+  resolveTsigEncryptionKey,
+} from '../secrets';
+
+describe('requireSecret', () => {
+  it('returns the provided value when non-empty', () => {
+    expect(requireSecret('X', 'real-secret', 'production', 'dev')).toBe('real-secret');
+  });
+
+  it('throws in production when value is undefined', () => {
+    expect(() => requireSecret('SESSION_SECRET', undefined, 'production', 'dev')).toThrow(
+      /SESSION_SECRET must be set/
+    );
+  });
+
+  it('throws in production when value is empty or whitespace', () => {
+    expect(() => requireSecret('X', '', 'production', 'dev')).toThrow(/must be set/);
+    expect(() => requireSecret('X', '   ', 'production', 'dev')).toThrow(/must be set/);
+  });
+
+  it('falls back to the dev value outside production', () => {
+    expect(requireSecret('X', undefined, 'development', 'dev-fallback')).toBe('dev-fallback');
+    expect(requireSecret('X', undefined, 'test', 'dev-fallback')).toBe('dev-fallback');
+    expect(requireSecret('X', undefined, undefined, 'dev-fallback')).toBe('dev-fallback');
+  });
+});
+
+describe('resolveSessionSecret', () => {
+  it('uses the env value when set', () => {
+    expect(resolveSessionSecret({ NODE_ENV: 'production', SESSION_SECRET: 'abc' })).toBe('abc');
+  });
+
+  it('throws in production when unset', () => {
+    expect(() => resolveSessionSecret({ NODE_ENV: 'production' })).toThrow(/SESSION_SECRET/);
+  });
+
+  it('returns a dev fallback outside production', () => {
+    expect(resolveSessionSecret({ NODE_ENV: 'development' })).toBeTruthy();
+  });
+});
+
+describe('resolveTsigEncryptionKey', () => {
+  it('uses the env value when set', () => {
+    expect(
+      resolveTsigEncryptionKey({ NODE_ENV: 'production', TSIG_ENCRYPTION_KEY: 'key' })
+    ).toBe('key');
+  });
+
+  it('throws in production when unset', () => {
+    expect(() => resolveTsigEncryptionKey({ NODE_ENV: 'production' })).toThrow(
+      /TSIG_ENCRYPTION_KEY/
+    );
+  });
+
+  it('returns a dev fallback outside production', () => {
+    expect(resolveTsigEncryptionKey({ NODE_ENV: 'test' })).toBeTruthy();
+  });
+});

--- a/backend/src/config/secrets.ts
+++ b/backend/src/config/secrets.ts
@@ -1,0 +1,58 @@
+// backend/src/config/secrets.ts
+// Centralized resolution of signing/encryption secrets with production fail-fast.
+//
+// A hardcoded, source-public secret is worthless: anyone who can read the repo
+// can forge sessions or decrypt stored TSIG keys. So in production we refuse to
+// start unless the operator supplies the secret via environment. In development
+// and test we keep a deterministic fallback so local runs and the test suite
+// work without extra setup (and so existing dev-encrypted data still decrypts).
+
+// Dev/test-only fallbacks. NEVER relied upon in production (see requireSecret).
+const DEV_SESSION_SECRET = 'dev-insecure-session-secret-do-not-use-in-production';
+// Kept identical to the historical default so existing dev-encrypted TSIG keys
+// remain decryptable in development after this change.
+const DEV_TSIG_ENCRYPTION_KEY = 'change-this-32-char-key-in-prod!';
+
+/**
+ * Return `value` if it is a non-empty secret. Otherwise fail fast in production
+ * (throw) and fall back to `devFallback` in any other environment.
+ */
+export function requireSecret(
+  name: string,
+  value: string | undefined,
+  nodeEnv: string | undefined,
+  devFallback: string
+): string {
+  if (value && value.trim().length > 0) {
+    return value;
+  }
+
+  if (nodeEnv === 'production') {
+    throw new Error(
+      `${name} must be set to a non-empty value in production. ` +
+        `Refusing to start with a fallback secret because it would allow ` +
+        `session forgery / unprotected key storage. Set ${name} in the environment.`
+    );
+  }
+
+  return devFallback;
+}
+
+/**
+ * Resolve the express-session signing secret. Throws in production if unset.
+ */
+export function resolveSessionSecret(env: NodeJS.ProcessEnv = process.env): string {
+  return requireSecret('SESSION_SECRET', env.SESSION_SECRET, env.NODE_ENV, DEV_SESSION_SECRET);
+}
+
+/**
+ * Resolve the TSIG-key-at-rest encryption secret. Throws in production if unset.
+ */
+export function resolveTsigEncryptionKey(env: NodeJS.ProcessEnv = process.env): string {
+  return requireSecret(
+    'TSIG_ENCRYPTION_KEY',
+    env.TSIG_ENCRYPTION_KEY,
+    env.NODE_ENV,
+    DEV_TSIG_ENCRYPTION_KEY
+  );
+}

--- a/backend/src/helpers/__tests__/session.test.ts
+++ b/backend/src/helpers/__tests__/session.test.ts
@@ -1,0 +1,42 @@
+// backend/src/helpers/__tests__/session.test.ts
+import { regenerateSession } from '../session';
+
+describe('regenerateSession', () => {
+  it('resolves and invokes session.regenerate exactly once on success', async () => {
+    const regenerate = jest.fn((cb: (err: unknown) => void) => cb(null));
+    await expect(regenerateSession({ regenerate })).resolves.toBeUndefined();
+    expect(regenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when regenerate yields an error', async () => {
+    const boom = new Error('store failure');
+    const regenerate = jest.fn((cb: (err: unknown) => void) => cb(boom));
+    await expect(regenerateSession({ regenerate })).rejects.toBe(boom);
+  });
+
+  it('wraps non-Error rejection reasons in an Error', async () => {
+    const regenerate = jest.fn((cb: (err: unknown) => void) => cb('string failure'));
+    await expect(regenerateSession({ regenerate })).rejects.toBeInstanceOf(Error);
+  });
+
+  it('does not populate fields before regeneration completes (ordering contract)', async () => {
+    // Simulates the login flow: fields must be set only after regenerate resolves.
+    const order: string[] = [];
+    const session = {
+      userId: undefined as string | undefined,
+      regenerate(cb: (err: unknown) => void) {
+        order.push('regenerate');
+        // Emulate express-session wiping the session before the callback.
+        this.userId = undefined;
+        cb(null);
+      },
+    };
+
+    await regenerateSession(session);
+    session.userId = 'user-1';
+    order.push('set-fields');
+
+    expect(order).toEqual(['regenerate', 'set-fields']);
+    expect(session.userId).toBe('user-1');
+  });
+});

--- a/backend/src/helpers/session.ts
+++ b/backend/src/helpers/session.ts
@@ -1,0 +1,25 @@
+// backend/src/helpers/session.ts
+// Session helpers for authentication routes.
+
+/** Minimal shape of the callback-style session APIs we wrap. */
+export interface RegenerableSession {
+  regenerate(callback: (err: unknown) => void): void;
+}
+
+/**
+ * Promisify express-session's callback-style `regenerate`. Call this BEFORE
+ * populating authenticated session fields so the pre-auth session id is
+ * discarded and a fresh one is issued — mitigating session fixation. Fields set
+ * after this resolves live on the new session, not the one that was wiped.
+ */
+export function regenerateSession(session: RegenerableSession): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    session.regenerate((err) => {
+      if (err) {
+        reject(err instanceof Error ? err : new Error(String(err)));
+        return;
+      }
+      resolve();
+    });
+  });
+}

--- a/backend/src/routes/__tests__/routeGuards.test.ts
+++ b/backend/src/routes/__tests__/routeGuards.test.ts
@@ -1,0 +1,50 @@
+// backend/src/routes/__tests__/routeGuards.test.ts
+// Verifies auth/write-access middleware is wired onto sensitive routes without
+// needing a full HTTP stack (no supertest in this project). We introspect the
+// Express router stack and assert the named middleware appears on the route.
+import webhookRouter from '../webhookRoutes';
+import backupRouter from '../backupRoutes';
+
+interface RouteLayer {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: { name: string } }>;
+  };
+}
+
+function handlerNamesFor(
+  router: { stack: RouteLayer[] },
+  method: string,
+  path: string
+): string[] {
+  const layer = router.stack.find(
+    (l) => l.route && l.route.path === path && l.route.methods[method]
+  );
+  if (!layer || !layer.route) {
+    throw new Error(`Route ${method.toUpperCase()} ${path} not found`);
+  }
+  return layer.route.stack.map((s) => s.handle.name);
+}
+
+describe('webhook notify route guards', () => {
+  it('POST /notify requires auth and write access (SSRF hardening)', () => {
+    const names = handlerNamesFor(webhookRouter as never, 'post', '/notify');
+    expect(names).toContain('requireAuth');
+    expect(names).toContain('requireWriteAccess');
+  });
+});
+
+describe('backup creation route guards', () => {
+  it('POST /zone/:zone requires auth and write access (viewers cannot write backups)', () => {
+    const names = handlerNamesFor(backupRouter as never, 'post', '/zone/:zone');
+    expect(names).toContain('requireAuth');
+    expect(names).toContain('requireWriteAccess');
+  });
+
+  it('GET /zone/:zone requires auth but not write access (viewers may read)', () => {
+    const names = handlerNamesFor(backupRouter as never, 'get', '/zone/:zone');
+    expect(names).toContain('requireAuth');
+    expect(names).not.toContain('requireWriteAccess');
+  });
+});

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -7,6 +7,7 @@ import { requireAuth, requireRole } from '../middleware/auth';
 import { LoginCredentials, UserCreateData, UserRole, AuthenticatedRequest } from '../types/auth';
 import { validateLogin, validateUserCreate, validateChangePassword } from '../middleware/validation';
 import { getClientIp } from '../helpers/ipHelpers';
+import { regenerateSession } from '../helpers/session';
 
 const router = Router();
 
@@ -63,6 +64,10 @@ router.post('/login', loginLimiter, validateLogin, async (req: Request, res: Res
         code: 'INVALID_CREDENTIALS'
       });
     }
+
+    // Regenerate the session id before populating authenticated fields so the
+    // pre-auth session id is discarded (session fixation mitigation).
+    await regenerateSession(req.session);
 
     // Create session
     req.session.userId = user.id;

--- a/backend/src/routes/backupRoutes.ts
+++ b/backend/src/routes/backupRoutes.ts
@@ -1,6 +1,6 @@
 // backend/src/routes/backupRoutes.ts
 import { Router, Request, Response } from 'express';
-import { requireAuth } from '../middleware/auth';
+import { requireAuth, requireWriteAccess } from '../middleware/auth';
 import { AuthenticatedRequest } from '../types/auth';
 import { backupService } from '../services/backupService';
 
@@ -101,7 +101,9 @@ router.get('/zone/:zone/:backupId', requireAuth, async (req: Request, res: Respo
  * POST /api/backups/zone/:zone
  * Create a new backup for a zone
  */
-router.post('/zone/:zone', requireAuth, async (req: Request, res: Response) => {
+// Creating a backup writes a server-side file, so it is a write operation:
+// viewers (read-only) must not be able to reach it.
+router.post('/zone/:zone', requireAuth, requireWriteAccess, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthenticatedRequest;
     const user = authReq.user!;

--- a/backend/src/routes/ssoAuthRoutes.ts
+++ b/backend/src/routes/ssoAuthRoutes.ts
@@ -7,6 +7,7 @@ import { userService } from '../services/userService';
 import { auditService, AuditEventType } from '../services/auditService';
 import { UserRole } from '../types/auth';
 import { getClientIp } from '../helpers/ipHelpers';
+import { regenerateSession } from '../helpers/session';
 
 const router = Router();
 
@@ -163,6 +164,11 @@ const handleCallback = async (req: Request, res: Response) => {
         },
       });
     }
+
+    // Regenerate the session id before populating authenticated fields so the
+    // pre-auth session id is discarded (session fixation mitigation). The
+    // post-login redirect below is preserved.
+    await regenerateSession(req.session);
 
     // Create session
     req.session.userId = user.id;

--- a/backend/src/routes/webhookRoutes.ts
+++ b/backend/src/routes/webhookRoutes.ts
@@ -3,6 +3,7 @@ import { Router, Request, Response } from 'express';
 import { WebhookConfig, WebhookPayload } from '../types/webhook';
 import { webhookService } from '../services/webhookService';
 import { webhookLimiter } from '../middleware/rateLimiter';
+import { requireAuth, requireWriteAccess } from '../middleware/auth';
 
 const router = Router();
 
@@ -14,7 +15,10 @@ interface WebhookRequestBody {
   payload: WebhookPayload;
 }
 
-router.post('/notify', async (req: Request<Record<string, never>, any, WebhookRequestBody>, res: Response) => {
+// Auth + write access required: this route triggers an outbound fetch to a
+// caller-supplied URL, so it must never be reachable unauthenticated (SSRF).
+// requireWriteAccess mirrors zoneRoutes: viewers cannot send notifications.
+router.post('/notify', requireAuth, requireWriteAccess, async (req: Request<Record<string, never>, any, WebhookRequestBody>, res: Response) => {
   try {
     const { config, payload } = req.body;
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -24,6 +24,7 @@ import webhookConfigRoutes from './routes/webhookConfigRoutes';
 import ssoConfigRoutes from './routes/ssoConfigRoutes';
 import auditRoutes from './routes/auditRoutes';
 import { config } from './config';
+import { resolveSessionSecret } from './config/secrets';
 import { readFileSync } from 'fs';
 
 // Application version, read from package.json (present next to dist/ at runtime).
@@ -90,7 +91,9 @@ const corsOptions = {
 // Session middleware - must be before routes
 app.use(session({
   store: sessionStore,
-  secret: process.env.SESSION_SECRET || 'change-this-secret-in-production',
+  // Fail fast in production if SESSION_SECRET is unset (see config/secrets.ts):
+  // a source-public fallback secret would allow session forgery.
+  secret: resolveSessionSecret(),
   resave: false,
   saveUninitialized: false,
   name: 'snap-dns.sid',

--- a/backend/src/services/__tests__/webhookUrlGuard.test.ts
+++ b/backend/src/services/__tests__/webhookUrlGuard.test.ts
@@ -1,0 +1,81 @@
+// backend/src/services/__tests__/webhookUrlGuard.test.ts
+import { checkWebhookUrl } from '../webhookUrlGuard';
+
+describe('checkWebhookUrl', () => {
+  describe('blocked targets', () => {
+    const blocked = [
+      'http://localhost/hook',
+      'https://localhost:8443/hook',
+      'http://sub.localhost/hook',
+      'http://127.0.0.1/hook',
+      'http://127.1.2.3/hook',
+      'http://0.0.0.0/hook',
+      'http://169.254.169.254/latest/meta-data', // cloud metadata
+      'http://169.254.0.1/hook', // link-local
+      'http://[::1]/hook', // IPv6 loopback
+      'http://[::]/hook', // IPv6 unspecified
+      'http://[fe80::1]/hook', // IPv6 link-local
+      'http://[::ffff:127.0.0.1]/hook', // IPv4-mapped loopback
+    ];
+
+    it.each(blocked)('blocks %s', (url) => {
+      const result = checkWebhookUrl(url);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBeTruthy();
+    });
+  });
+
+  describe('bad schemes and malformed URLs', () => {
+    it('rejects non-http(s) schemes', () => {
+      expect(checkWebhookUrl('file:///etc/passwd').allowed).toBe(false);
+      expect(checkWebhookUrl('ftp://example.com/x').allowed).toBe(false);
+      expect(checkWebhookUrl('gopher://example.com/x').allowed).toBe(false);
+    });
+
+    it('rejects malformed / empty URLs', () => {
+      expect(checkWebhookUrl('not a url').allowed).toBe(false);
+      expect(checkWebhookUrl('').allowed).toBe(false);
+      // @ts-expect-error testing runtime guard against non-string input
+      expect(checkWebhookUrl(undefined).allowed).toBe(false);
+    });
+  });
+
+  describe('private ranges are logged-but-allowed', () => {
+    const privateHosts = [
+      'http://10.0.0.5/hook',
+      'http://172.16.0.1/hook',
+      'http://172.31.255.255/hook',
+      'http://192.168.1.10/hook',
+      'http://[fc00::1]/hook',
+      'http://[fd12:3456::1]/hook',
+    ];
+
+    it.each(privateHosts)('allows %s with a warning', (url) => {
+      const result = checkWebhookUrl(url);
+      expect(result.allowed).toBe(true);
+      expect(result.warning).toBeTruthy();
+    });
+
+    it('does not treat 172.32.x (outside /12) as private', () => {
+      const result = checkWebhookUrl('http://172.32.0.1/hook');
+      expect(result.allowed).toBe(true);
+      expect(result.warning).toBeUndefined();
+    });
+  });
+
+  describe('public targets are allowed without warning', () => {
+    const allowed = [
+      'https://hooks.slack.com/services/T000/B000/XXXX',
+      'https://discord.com/api/webhooks/123/abc',
+      'https://example.com/webhook',
+      'http://93.184.216.34/hook', // public IPv4 literal
+    ];
+
+    it.each(allowed)('allows %s', (url) => {
+      const result = checkWebhookUrl(url);
+      expect(result.allowed).toBe(true);
+      expect(result.warning).toBeUndefined();
+      expect(result.reason).toBeUndefined();
+    });
+  });
+});

--- a/backend/src/services/tsigKeyService.ts
+++ b/backend/src/services/tsigKeyService.ts
@@ -4,11 +4,14 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import crypto from 'crypto';
+import { resolveTsigEncryptionKey } from '../config/secrets';
 
 const KEYS_FILE = path.join(process.cwd(), 'data', 'tsig-keys.json');
 
-// Encryption key for storing TSIG keys (should be from env in production)
-const ENCRYPTION_KEY = process.env.TSIG_ENCRYPTION_KEY || 'change-this-32-char-key-in-prod!';
+// Encryption key for TSIG keys at rest. Fail fast in production if unset (see
+// config/secrets.ts): a forgotten key means the stored secrets are effectively
+// unprotected by a source-public default.
+const ENCRYPTION_KEY = resolveTsigEncryptionKey();
 const ALGORITHM = 'aes-256-cbc';
 
 export interface TSIGKey {

--- a/backend/src/services/webhookService.ts
+++ b/backend/src/services/webhookService.ts
@@ -2,6 +2,7 @@
 import { WebhookConfig, WebhookResponse } from '../types/webhook';
 import type { WebhookPayload as ImportedWebhookPayload } from '../types/webhook';
 import fetch from 'node-fetch';
+import { checkWebhookUrl } from './webhookUrlGuard';
 
 export type WebhookPayload = ImportedWebhookPayload;
 
@@ -250,6 +251,21 @@ class WebhookService {
 
   async send(config: WebhookConfig, payload: WebhookPayload): Promise<WebhookResponse> {
     try {
+      // SSRF guard: applied here (not only on the route) so the webhook-config
+      // test path is covered too. Blocked targets never reach fetch().
+      const urlCheck = checkWebhookUrl(config.url);
+      if (!urlCheck.allowed) {
+        console.warn(`Blocked webhook request to disallowed URL: ${urlCheck.reason}`);
+        return {
+          success: false,
+          error: 'Webhook URL is not allowed',
+          details: urlCheck.reason,
+        };
+      }
+      if (urlCheck.warning) {
+        console.warn(`Webhook request to private target allowed: ${urlCheck.warning}`);
+      }
+
       const formattedPayload = this.formatPayload(config.provider, payload);
 
       // Webhook URLs embed secret tokens (Slack/Discord/Teams/Mattermost) - never log them.

--- a/backend/src/services/webhookUrlGuard.ts
+++ b/backend/src/services/webhookUrlGuard.ts
@@ -1,0 +1,156 @@
+// backend/src/services/webhookUrlGuard.ts
+// Outbound SSRF guard for webhook target URLs.
+//
+// Policy (documented deliberately):
+//   - Scheme MUST be http or https. Anything else (file:, gopher:, ftp:, etc.)
+//     is rejected outright.
+//   - ALWAYS BLOCK loopback (localhost, 127.0.0.0/8, ::1), the unspecified
+//     address (0.0.0.0, ::), and link-local / cloud-metadata ranges
+//     (169.254.0.0/16 incl. 169.254.169.254, IPv6 fe80::/10). These are never
+//     legitimate webhook destinations and are the classic SSRF pivots.
+//   - LOG-BUT-ALLOW RFC1918 / unique-local private ranges (10/8, 172.16-31/12,
+//     192.168/16, fc00::/7). Internal chat webhooks (self-hosted Mattermost,
+//     etc.) commonly live on private networks, so blocking these outright would
+//     break legitimate use. We surface a warning instead.
+//   - Hostnames that are not IP literals are allowed as-is. NOTE: this guard
+//     inspects only the literal URL; it does not resolve DNS, so a hostname that
+//     resolves to an internal IP (DNS-rebinding style) is not caught here. That
+//     is an accepted limitation of a synchronous, unit-testable string guard.
+
+export interface WebhookUrlCheck {
+  /** Whether the URL is permitted to be fetched. */
+  allowed: boolean;
+  /** Human-readable reason the URL was blocked (only when allowed === false). */
+  reason?: string;
+  /** Non-fatal note (e.g. private range) worth logging (only when allowed === true). */
+  warning?: string;
+}
+
+/** Parse a dotted-quad IPv4 string into four octets, or null if not IPv4. */
+function parseIPv4(host: string): [number, number, number, number] | null {
+  const parts = host.split('.');
+  if (parts.length !== 4) return null;
+  const octets: number[] = [];
+  for (const part of parts) {
+    // Reject empty, non-numeric, and leading-zero forms.
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const n = Number(part);
+    if (n > 255) return null;
+    octets.push(n);
+  }
+  return [octets[0], octets[1], octets[2], octets[3]];
+}
+
+/** Classify an IPv4 address: 'block', 'warn' (private), or 'allow'. */
+function classifyIPv4(octets: [number, number, number, number]): 'block' | 'warn' | 'allow' {
+  const [a, b] = octets;
+
+  // Always block: loopback, unspecified/this-host, link-local (incl. metadata).
+  if (a === 127) return 'block'; // 127.0.0.0/8 loopback
+  if (a === 0) return 'block'; // 0.0.0.0/8 "this host"
+  if (a === 169 && b === 254) return 'block'; // 169.254.0.0/16 link-local + 169.254.169.254 metadata
+
+  // Log-but-allow: RFC1918 private ranges.
+  if (a === 10) return 'warn'; // 10.0.0.0/8
+  if (a === 172 && b >= 16 && b <= 31) return 'warn'; // 172.16.0.0/12
+  if (a === 192 && b === 168) return 'warn'; // 192.168.0.0/16
+
+  return 'allow';
+}
+
+/** Classify an IPv6 host (already unbracketed). Returns null if not IPv6. */
+function classifyIPv6(host: string): 'block' | 'warn' | 'allow' | null {
+  if (!host.includes(':')) return null;
+  const lower = host.toLowerCase();
+
+  // IPv4-mapped addresses (::ffff:a.b.c.d). Node normalizes the dotted form to
+  // hex hextets (e.g. ::ffff:127.0.0.1 -> ::ffff:7f00:1), so decode both.
+  if (lower.startsWith('::ffff:')) {
+    const rest = lower.slice('::ffff:'.length);
+    if (rest.includes('.')) {
+      const v4 = parseIPv4(rest);
+      if (v4) return classifyIPv4(v4);
+    } else {
+      const groups = rest.split(':');
+      if (groups.length === 2 && groups.every((g) => /^[0-9a-f]{1,4}$/.test(g))) {
+        const hi = parseInt(groups[0], 16);
+        const lo = parseInt(groups[1], 16);
+        const v4: [number, number, number, number] = [
+          (hi >> 8) & 0xff,
+          hi & 0xff,
+          (lo >> 8) & 0xff,
+          lo & 0xff,
+        ];
+        return classifyIPv4(v4);
+      }
+    }
+  }
+
+  // Loopback and unspecified.
+  if (lower === '::1' || lower === '::') return 'block';
+
+  // Link-local fe80::/10 (fe80..febf) — analogous to IPv4 169.254, block.
+  if (/^fe[89ab]/.test(lower)) return 'block';
+
+  // Unique-local fc00::/7 (fc.. / fd..) — private, log-but-allow.
+  if (/^f[cd]/.test(lower)) return 'warn';
+
+  return 'allow';
+}
+
+/**
+ * Evaluate whether a webhook target URL is safe to fetch. Pure and synchronous
+ * so it can be unit-tested and applied both on the API route and in the service.
+ */
+export function checkWebhookUrl(rawUrl: string): WebhookUrlCheck {
+  if (!rawUrl || typeof rawUrl !== 'string') {
+    return { allowed: false, reason: 'Webhook URL is missing' };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return { allowed: false, reason: 'Webhook URL is not a valid URL' };
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return {
+      allowed: false,
+      reason: `Unsupported URL scheme "${parsed.protocol}"; only http and https are allowed`,
+    };
+  }
+
+  // Node's URL#hostname keeps the surrounding brackets on IPv6 literals
+  // (e.g. "[::1]"); strip them so classification sees the bare address.
+  let host = parsed.hostname.toLowerCase();
+  if (host.startsWith('[') && host.endsWith(']')) {
+    host = host.slice(1, -1);
+  }
+
+  if (host === 'localhost' || host.endsWith('.localhost')) {
+    return { allowed: false, reason: 'Webhook URL targets localhost' };
+  }
+
+  const v4 = parseIPv4(host);
+  if (v4) {
+    const verdict = classifyIPv4(v4);
+    if (verdict === 'block') {
+      return { allowed: false, reason: `Webhook URL targets a blocked address (${host})` };
+    }
+    if (verdict === 'warn') {
+      return { allowed: true, warning: `Webhook URL targets a private address (${host})` };
+    }
+    return { allowed: true };
+  }
+
+  const v6 = classifyIPv6(host);
+  if (v6 === 'block') {
+    return { allowed: false, reason: `Webhook URL targets a blocked address (${host})` };
+  }
+  if (v6 === 'warn') {
+    return { allowed: true, warning: `Webhook URL targets a private address (${host})` };
+  }
+
+  return { allowed: true };
+}


### PR DESCRIPTION
## Summary

Four confirmed backend security fixes from the authz audit (all spot-checked against code before work began):

- **Unauthenticated SSRF via `POST /api/webhook/notify`**: the route had only a rate limiter. Added `requireAuth` + `requireWriteAccess`, plus a new pure `checkWebhookUrl()` guard applied in `webhookService.send()` (covers the webhook-config path too). Policy: scheme must be http/https; **always block** loopback, unspecified, and link-local/cloud-metadata (169.254.169.254) including IPv4-mapped forms; **log-but-allow** RFC1918/unique-local (self-hosted Mattermost etc. are legitimate). Documented limitation: literal-URL only, no DNS resolution (rebinding not caught by a synchronous guard).
- **Fallback production secrets**: `SESSION_SECRET` fell back to a source-public string, and `TSIG_ENCRYPTION_KEY` had the same footgun. New `config/secrets.ts` fails fast on startup when either is unset in `NODE_ENV=production`; dev/test fallbacks kept byte-identical so existing dev-encrypted keys still decrypt.
- **Session fixation**: no `regenerate` on login. Added `req.session.regenerate()` (promisified) before populating the session in both local login and the SSO callback; SSO redirect preserved.
- **Viewer-writable backups**: `POST /api/backups/zone/:zone` gained `requireWriteAccess`.

Scope stayed out of `middleware/auth.ts` (owned by the parallel session-privilege branch #40).

## Testing

New unit suites: SSRF guard (block/warn/allow incl. IPv4-mapped and bad schemes), secret fail-fast, regenerate helper, and a router-stack introspection test asserting the webhook/backup routes carry both guards. Backend 223 tests green; lint clean on new files; build clean. No supertest infra exists, so the full HTTP login/session path is covered structurally rather than end-to-end (noted).