### PR TITLE
fix(snapshots): partial restore must not delete unselected records

### DIFF
--- a/src/components/Snapshots.tsx
+++ b/src/components/Snapshots.tsx
@@ -300,6 +300,139 @@ const compareSOA = (record1: DNSRecord, record2: DNSRecord): boolean => {
   return JSON.stringify(soa1) === JSON.stringify(soa2);
 };
 
+// Value-aware equality for two records of the same name/type. Pure; used by the
+// restore-diff computation below and the comparison UI.
+export const isRecordEqual = (record1: DNSRecord, record2: DNSRecord): boolean => {
+  if (record1.name !== record2.name || record1.type !== record2.type) {
+    return false;
+  }
+
+  switch (record1.type) {
+    case 'SOA':
+      return compareSOA(record1, record2);
+    case 'MX': {
+      const [prio1, exchange1] = String(record1.value).split(/\s+/);
+      const [prio2, exchange2] = String(record2.value).split(/\s+/);
+      return parseInt(prio1) === parseInt(prio2) &&
+             exchange1.toLowerCase().replace(/\.+$/, '') === exchange2.toLowerCase().replace(/\.+$/, '');
+    }
+    case 'SRV': {
+      const [p1, w1, port1, target1] = String(record1.value).split(/\s+/);
+      const [p2, w2, port2, target2] = String(record2.value).split(/\s+/);
+      return parseInt(p1) === parseInt(p2) &&
+             parseInt(w1) === parseInt(w2) &&
+             parseInt(port1) === parseInt(port2) &&
+             target1.toLowerCase().replace(/\.+$/, '') === target2.toLowerCase().replace(/\.+$/, '');
+    }
+    default:
+      return record1.value.toString().toLowerCase().replace(/\.+$/, '') ===
+             record2.value.toString().toLowerCase().replace(/\.+$/, '') &&
+             record1.ttl === record2.ttl &&
+             (record1.class || 'IN') === (record2.class || 'IN');
+  }
+};
+
+// A single change intent produced by computeRestoreChanges. Shape matches the
+// pending-change objects consumed by PendingChangesContext.addPendingChange.
+export interface RestoreChange {
+  type: 'ADD' | 'MODIFY' | 'DELETE';
+  zone: string;
+  keyId: string;
+  record?: DNSRecord;
+  originalRecord?: DNSRecord;
+  newRecord?: DNSRecord;
+  source: { type: 'backup'; id: string | number; timestamp: number };
+}
+
+interface RestoreChangeContext {
+  zone: string;
+  keyId: string;
+  source: { type: 'backup'; id: string | number; timestamp: number };
+}
+
+// Pure diff between a snapshot and the current zone, producing the set of
+// pending changes for a restore. Two modes:
+//
+//   Partial restore (isFullRestore=false): the user picked a SUBSET of the
+//   snapshot's records to bring back. We only ADD/MODIFY those selected records
+//   and NEVER delete anything — the user asked to restore specific records, not
+//   to prune the zone.
+//
+//   Full restore (isFullRestore=true): make the zone match the snapshot exactly.
+//   ADD/MODIFY the selected records (which equal the full snapshot) AND delete
+//   current records that are absent from the snapshot (drift removal).
+//
+// The deletion baseline is ALWAYS `snapshotRecords` (the full snapshot), never
+// `selectedRecords`. This is the crux of the partial-restore data-loss fix:
+// computing deletions against the selected subset would wipe every unselected
+// record even though the snapshot still contains it.
+export const computeRestoreChanges = (
+  currentRecords: DNSRecord[],
+  snapshotRecords: DNSRecord[],
+  selectedRecords: DNSRecord[],
+  isFullRestore: boolean,
+  context: RestoreChangeContext
+): RestoreChange[] => {
+  const { zone, keyId, source } = context;
+  const changes: RestoreChange[] = [];
+
+  const filteredSelected = selectedRecords.filter(r => (r.type as string) !== 'TSIG');
+  const filteredCurrent = currentRecords.filter(r => (r.type as string) !== 'TSIG');
+  const filteredSnapshot = snapshotRecords.filter(r => (r.type as string) !== 'TSIG');
+
+  // Add/modify pass: bring the selected records back into the zone.
+  filteredSelected.forEach(record => {
+    const normalizedRecord: DNSRecord = {
+      ...record,
+      name: record.name,
+      type: record.type,
+      value: record.value,
+      ttl: record.ttl || 3600,
+      class: record.class || 'IN'
+    };
+
+    const exactMatch = filteredCurrent.find(r =>
+      r.name === normalizedRecord.name &&
+      r.type === normalizedRecord.type &&
+      isRecordEqual(r, normalizedRecord)
+    );
+
+    if (!exactMatch) {
+      const partialMatch = filteredCurrent.find(r =>
+        r.name === normalizedRecord.name &&
+        r.type === normalizedRecord.type
+      );
+
+      if (partialMatch) {
+        changes.push({ type: 'MODIFY', zone, keyId, originalRecord: partialMatch, newRecord: normalizedRecord, source });
+      } else {
+        changes.push({ type: 'ADD', zone, keyId, record: normalizedRecord, source });
+      }
+    }
+  });
+
+  // Deletion (drift-removal) pass: ONLY for a full-snapshot restore. Prune
+  // current records that are absent from the FULL snapshot so the zone ends up
+  // matching the snapshot. Skipped entirely for a partial selection.
+  if (isFullRestore) {
+    filteredCurrent.forEach(currentRecord => {
+      if (currentRecord.type === 'SOA') return;
+
+      const inSnapshot = filteredSnapshot.find(r =>
+        r.name === currentRecord.name &&
+        r.type === currentRecord.type &&
+        isRecordEqual(currentRecord, r)
+      );
+
+      if (!inSnapshot) {
+        changes.push({ type: 'DELETE', zone, keyId, record: currentRecord, source });
+      }
+    });
+  }
+
+  return changes;
+};
+
 function Snapshots() {
   const { addPendingChange, setShowPendingDrawer } = usePendingChanges();
   const { config } = useConfig();
@@ -360,6 +493,23 @@ function Snapshots() {
     if (!selectedZone) return [];
     return backendKeys.filter(key => key.zones?.includes(selectedZone)) || [];
   }, [backendKeys, selectedZone]);
+
+  // Auto-select the DNS key that serves the chosen zone in the Create Snapshot
+  // panel, mirroring the Zone Editor sidebar: keep the current key if it still
+  // serves the zone, otherwise pick the first key whose `zones` include it. This
+  // stops the "select a zone but the key stays empty" confusion.
+  useEffect(() => {
+    if (!selectedZone) {
+      setSelectedKeyId('');
+      return;
+    }
+    setSelectedKeyId(prev => {
+      if (prev && availableKeys.some(key => key.id === prev)) {
+        return prev;
+      }
+      return availableKeys[0]?.id || '';
+    });
+  }, [selectedZone, availableKeys]);
 
   useEffect(() => {
     const loadBackups = async () => {
@@ -702,39 +852,14 @@ function Snapshots() {
     return { added, removed, modified, unchanged: [] };
   };
 
-  const isRecordEqual = (record1: DNSRecord, record2: DNSRecord): boolean => {
-    if (record1.name !== record2.name || record1.type !== record2.type) {
-      return false;
-    }
-
-    switch (record1.type) {
-      case 'SOA':
-        return compareSOA(record1, record2);
-      case 'MX': {
-        const [prio1, exchange1] = String(record1.value).split(/\s+/);
-        const [prio2, exchange2] = String(record2.value).split(/\s+/);
-        return parseInt(prio1) === parseInt(prio2) &&
-               exchange1.toLowerCase().replace(/\.+$/, '') === exchange2.toLowerCase().replace(/\.+$/, '');
-      }
-      case 'SRV': {
-        const [p1, w1, port1, target1] = String(record1.value).split(/\s+/);
-        const [p2, w2, port2, target2] = String(record2.value).split(/\s+/);
-        return parseInt(p1) === parseInt(p2) &&
-               parseInt(w1) === parseInt(w2) &&
-               parseInt(port1) === parseInt(port2) &&
-               target1.toLowerCase().replace(/\.+$/, '') === target2.toLowerCase().replace(/\.+$/, '');
-      }
-      default:
-        return record1.value.toString().toLowerCase().replace(/\.+$/, '') ===
-               record2.value.toString().toLowerCase().replace(/\.+$/, '') &&
-               record1.ttl === record2.ttl &&
-               (record1.class || 'IN') === (record2.class || 'IN');
-    }
-  };
-
-  const confirmRestore = async (recordsToRestore: DNSRecord[]) => {
+  // Queue a restore. `isFullRestore` distinguishes the two modes handled by
+  // computeRestoreChanges: partial (add/modify the selected subset only) vs full
+  // (make the zone match the snapshot, including drift deletions). The deletion
+  // baseline is always the full snapshot (`selectedBackup.records`), never the
+  // selected subset.
+  const confirmRestore = async (recordsToRestore: DNSRecord[], isFullRestore = false) => {
     try {
-      const keyForZone = backendKeys.find(k => k.zones.includes(selectedBackup.zone));
+      const keyForZone = backendKeys.find(k => k.zones?.includes(selectedBackup.zone));
 
       if (!keyForZone) {
         throw new Error('No key found for this zone');
@@ -742,85 +867,21 @@ function Snapshots() {
 
       const currentRecords = await dnsService.fetchZoneRecords(selectedBackup.zone);
 
-      const changes: any[] = [];
-
-      const filteredRecordsToRestore = recordsToRestore.filter(r => r.type !== 'TSIG');
-      const filteredCurrentRecords = currentRecords.filter(r => (r.type as string) !== 'TSIG');
-
-      filteredRecordsToRestore.forEach(record => {
-        const normalizedRecord: DNSRecord = {
-          ...record,
-          name: record.name,
-          type: record.type,
-          value: record.value,
-          ttl: record.ttl || 3600,
-          class: record.class || 'IN'
-        };
-
-        const exactMatch = filteredCurrentRecords.find(r =>
-          r.name === normalizedRecord.name &&
-          r.type === normalizedRecord.type &&
-          isRecordEqual(r, normalizedRecord)
-        );
-
-        if (!exactMatch) {
-          const partialMatch = filteredCurrentRecords.find(r =>
-            r.name === normalizedRecord.name &&
-            r.type === normalizedRecord.type
-          );
-
-          if (partialMatch) {
-            changes.push({
-              type: 'MODIFY',
-              zone: selectedBackup.zone,
-              keyId: keyForZone.id,
-              originalRecord: partialMatch,
-              newRecord: normalizedRecord,
-              source: {
-                type: 'backup',
-                id: selectedBackup.id,
-                timestamp: selectedBackup.timestamp
-              }
-            });
-          } else {
-            changes.push({
-              type: 'ADD',
-              zone: selectedBackup.zone,
-              keyId: keyForZone.id,
-              record: normalizedRecord,
-              source: {
-                type: 'backup',
-                id: selectedBackup.id,
-                timestamp: selectedBackup.timestamp
-              }
-            });
+      const changes = computeRestoreChanges(
+        currentRecords,
+        selectedBackup.records || [],
+        recordsToRestore,
+        isFullRestore,
+        {
+          zone: selectedBackup.zone,
+          keyId: keyForZone.id,
+          source: {
+            type: 'backup',
+            id: selectedBackup.id,
+            timestamp: selectedBackup.timestamp
           }
         }
-      });
-
-      filteredCurrentRecords.forEach(currentRecord => {
-        if (currentRecord.type === 'SOA') return;
-
-        const inSnapshot = filteredRecordsToRestore.find(r =>
-          r.name === currentRecord.name &&
-          r.type === currentRecord.type &&
-          isRecordEqual(currentRecord, r)
-        );
-
-        if (!inSnapshot) {
-          changes.push({
-            type: 'DELETE',
-            zone: selectedBackup.zone,
-            keyId: keyForZone.id,
-            record: currentRecord,
-            source: {
-              type: 'backup',
-              id: selectedBackup.id,
-              timestamp: selectedBackup.timestamp
-            }
-          });
-        }
-      });
+      );
 
       if (changes.length === 0) {
         showInfo('No changes needed - all selected records are already up to date');
@@ -940,7 +1001,7 @@ function Snapshots() {
               variant="contained"
               startIcon={<BackupIcon />}
               onClick={handleBackup}
-              disabled={loading || !selectedZone}
+              disabled={loading || !selectedZone || !selectedKeyId}
             >
               Create Snapshot
             </Button>
@@ -1478,7 +1539,9 @@ function Snapshots() {
             onClick={async () => {
               setCompareDialogOpen(false);
               setRecordsToRestore(selectedBackup.records);
-              await confirmRestore(selectedBackup.records);
+              // Full restore: make the zone match the snapshot exactly (adds,
+              // modifies, and drift deletions against the full snapshot).
+              await confirmRestore(selectedBackup.records, true);
             }}
             color="warning"
             variant="contained"

--- a/src/components/__tests__/Snapshots.restore.test.ts
+++ b/src/components/__tests__/Snapshots.restore.test.ts
@@ -1,0 +1,151 @@
+// src/components/__tests__/Snapshots.restore.test.ts
+import { computeRestoreChanges, isRecordEqual, RestoreChange } from '../Snapshots';
+import { DNSRecord } from '../../types/dns';
+
+const rec = (name: string, type: string, value: string | object, ttl = 3600): DNSRecord => ({
+  name,
+  type,
+  value,
+  ttl,
+  class: 'IN'
+});
+
+const ctx = {
+  zone: 'example.com',
+  keyId: 'key-1',
+  source: { type: 'backup' as const, id: 'backup-1', timestamp: 1000 }
+};
+
+const byType = (changes: RestoreChange[], type: RestoreChange['type']) =>
+  changes.filter(c => c.type === type);
+
+describe('computeRestoreChanges', () => {
+  describe('partial restore (isFullRestore = false)', () => {
+    it('only adds/modifies the selected records and never deletes', () => {
+      const current = [rec('a', 'A', '1.1.1.1'), rec('b', 'A', '2.2.2.2'), rec('c', 'A', '3.3.3.3')];
+      const snapshot = [
+        rec('a', 'A', '1.1.1.1'),
+        rec('b', 'A', '2.2.2.2'),
+        rec('c', 'A', '3.3.3.3'),
+        rec('qa-test', 'A', '9.9.9.9')
+      ];
+      const selected = [rec('qa-test', 'A', '9.9.9.9')];
+
+      const changes = computeRestoreChanges(current, snapshot, selected, false, ctx);
+
+      expect(byType(changes, 'ADD')).toHaveLength(1);
+      expect(byType(changes, 'ADD')[0].record?.name).toBe('qa-test');
+      expect(byType(changes, 'DELETE')).toHaveLength(0);
+      expect(byType(changes, 'MODIFY')).toHaveLength(0);
+    });
+
+    it('regression: selecting one record from a large snapshot does not wipe the zone', () => {
+      // Reproduces the live-QA report: 34 current records all present in the
+      // snapshot, plus one record (qa-test) to bring back. A partial restore
+      // must queue exactly "1 add, 0 deletions", never 34 deletions.
+      const current = Array.from({ length: 34 }, (_, i) => rec(`host${i}`, 'A', `10.0.0.${i}`));
+      const snapshot = [...current, rec('qa-test', 'A', '9.9.9.9')];
+      const selected = [rec('qa-test', 'A', '9.9.9.9')];
+
+      const changes = computeRestoreChanges(current, snapshot, selected, false, ctx);
+
+      expect(byType(changes, 'ADD')).toHaveLength(1);
+      expect(byType(changes, 'DELETE')).toHaveLength(0);
+      expect(changes).toHaveLength(1);
+    });
+
+    it('modifies a selected record whose value drifted, without deleting others', () => {
+      const current = [rec('a', 'A', '1.1.1.1'), rec('b', 'A', '2.2.2.2')];
+      const snapshot = [rec('a', 'A', '9.9.9.9'), rec('b', 'A', '2.2.2.2')];
+      const selected = [rec('a', 'A', '9.9.9.9')];
+
+      const changes = computeRestoreChanges(current, snapshot, selected, false, ctx);
+
+      expect(byType(changes, 'MODIFY')).toHaveLength(1);
+      expect(byType(changes, 'MODIFY')[0].newRecord?.value).toBe('9.9.9.9');
+      expect(byType(changes, 'DELETE')).toHaveLength(0);
+    });
+
+    it('queues no changes when the selected record already matches', () => {
+      const current = [rec('a', 'A', '1.1.1.1'), rec('b', 'A', '2.2.2.2')];
+      const snapshot = [rec('a', 'A', '1.1.1.1'), rec('b', 'A', '2.2.2.2')];
+      const selected = [rec('a', 'A', '1.1.1.1')];
+
+      const changes = computeRestoreChanges(current, snapshot, selected, false, ctx);
+
+      expect(changes).toHaveLength(0);
+    });
+  });
+
+  describe('full restore (isFullRestore = true)', () => {
+    it('adds missing, modifies drifted, and deletes records absent from the snapshot', () => {
+      const current = [
+        rec('a', 'A', '1.1.1.1'),
+        rec('b', 'A', '2.2.2.2'), // drifted from snapshot
+        rec('x', 'A', '8.8.8.8')  // drift: not in snapshot
+      ];
+      const snapshot = [
+        rec('a', 'A', '1.1.1.1'),
+        rec('b', 'A', '5.5.5.5'), // original value
+        rec('c', 'A', '3.3.3.3')  // missing from current
+      ];
+
+      const changes = computeRestoreChanges(current, snapshot, snapshot, true, ctx);
+
+      expect(byType(changes, 'ADD').map(c => c.record?.name)).toEqual(['c']);
+      expect(byType(changes, 'MODIFY').map(c => c.newRecord?.name)).toEqual(['b']);
+      expect(byType(changes, 'DELETE').map(c => c.record?.name)).toContain('x');
+      // 'a' is unchanged and present in the snapshot: never deleted.
+      expect(byType(changes, 'DELETE').map(c => c.record?.name)).not.toContain('a');
+    });
+
+    it('deletion baseline is the full snapshot, not the selected subset', () => {
+      // Even if a caller passes a subset as `selectedRecords`, deletions must be
+      // computed against the full snapshot so present records survive.
+      const current = [rec('a', 'A', '1.1.1.1'), rec('b', 'A', '2.2.2.2')];
+      const snapshot = [rec('a', 'A', '1.1.1.1'), rec('b', 'A', '2.2.2.2')];
+      const selected = [rec('a', 'A', '1.1.1.1')]; // subset
+
+      const changes = computeRestoreChanges(current, snapshot, selected, true, ctx);
+
+      // 'b' is in the full snapshot -> not deleted despite not being selected.
+      expect(byType(changes, 'DELETE')).toHaveLength(0);
+    });
+
+    it('never deletes the SOA record even when it drifts', () => {
+      const soaCurrent = rec('example.com', 'SOA', 'ns1 admin 5 10 20 30 40');
+      const soaSnapshot = rec('example.com', 'SOA', 'ns1 admin 1 10 20 30 40');
+      const current = [soaCurrent, rec('orphan', 'A', '7.7.7.7')];
+      const snapshot = [soaSnapshot];
+
+      const changes = computeRestoreChanges(current, snapshot, snapshot, true, ctx);
+
+      expect(byType(changes, 'DELETE').map(c => c.record?.type)).not.toContain('SOA');
+      expect(byType(changes, 'DELETE').map(c => c.record?.name)).toContain('orphan');
+    });
+
+    it('ignores TSIG records on both sides', () => {
+      const current = [rec('a', 'A', '1.1.1.1'), rec('key', 'TSIG', 'sig')];
+      const snapshot = [rec('a', 'A', '1.1.1.1'), rec('key', 'TSIG', 'sig')];
+
+      const changes = computeRestoreChanges(current, snapshot, snapshot, true, ctx);
+
+      expect(changes).toHaveLength(0);
+    });
+  });
+});
+
+describe('isRecordEqual', () => {
+  it('treats trailing dots and case as equal for CNAME-like values', () => {
+    expect(isRecordEqual(rec('a', 'CNAME', 'Host.Example.com.'), rec('a', 'CNAME', 'host.example.com'))).toBe(true);
+  });
+
+  it('returns false when A record values differ', () => {
+    expect(isRecordEqual(rec('a', 'A', '1.1.1.1'), rec('a', 'A', '2.2.2.2'))).toBe(false);
+  });
+
+  it('compares MX priority and exchange regardless of case/dot', () => {
+    expect(isRecordEqual(rec('a', 'MX', '10 Mail.Example.com.'), rec('a', 'MX', '10 mail.example.com'))).toBe(true);
+    expect(isRecordEqual(rec('a', 'MX', '10 mail.example.com'), rec('a', 'MX', '20 mail.example.com'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

**Data-loss bug found in live QA.** Restoring a *subset* of records from a snapshot queued a DELETE for every record in the zone that wasn't selected — including records present identically in the snapshot being restored. Selecting one record produced "1 add, 34 deletions"; applying it would have wiped the zone down to the selection.

Root cause: the drift-deletion pass compared current records against `filteredRecordsToRestore` (the user-selected subset) instead of the full snapshot, treating the subset as the complete desired state.

Fix: the restore diff is extracted into a pure, tested `computeRestoreChanges(current, snapshot, selected, isFullRestore, ...)`. Deletions are queued **only** on a full restore ("Restore All Changes" in the Compare dialog), and their baseline is **always the full snapshot** — a current record is deleted only if absent from the whole snapshot (never SOA/TSIG). Partial restore (the per-record selection dialog) queues zero deletions; it only adds/modifies the chosen records.

Also fixes a related snapshot nit: the Create Snapshot panel now auto-selects the key serving the chosen zone (matching the Zone Editor) and disables Create until a key is set.

## Testing

New `Snapshots.restore.test.ts` (11 cases): the exact "1 add, 34 deletions" regression now yields 1 add / 0 deletes; partial-restore-never-deletes invariant; full-restore add/modify/delete; deletion-baseline-is-full-snapshot; SOA never deleted; TSIG ignored. `tsc` clean; 236 tests green; one fewer eslint warning than baseline.