### PR TITLE
fix(ui): tooltip console spam, stale helper text, mobile row actions

### DIFF
--- a/src/components/AuditLog.tsx
+++ b/src/components/AuditLog.tsx
@@ -186,14 +186,18 @@ const AuditLog: React.FC = () => {
         <Typography variant="h5">Audit Logs</Typography>
         <Box>
           <Tooltip title="Refresh logs">
-            <IconButton onClick={loadLogs} disabled={loading}>
-              <RefreshIcon />
-            </IconButton>
+            <span>
+              <IconButton onClick={loadLogs} disabled={loading}>
+                <RefreshIcon />
+              </IconButton>
+            </span>
           </Tooltip>
           <Tooltip title="Export as CSV">
-            <IconButton onClick={handleExportCSV} disabled={filteredEntries.length === 0}>
-              <DownloadIcon />
-            </IconButton>
+            <span>
+              <IconButton onClick={handleExportCSV} disabled={filteredEntries.length === 0}>
+                <DownloadIcon />
+              </IconButton>
+            </span>
           </Tooltip>
           <Button
             variant="outlined"

--- a/src/components/KeySelector.tsx
+++ b/src/components/KeySelector.tsx
@@ -149,9 +149,11 @@ function KeySelector() {
             ))}
         </Select>
         <FormHelperText>
-          {!selectedKey
-            ? 'Select a zone and a matching key is chosen automatically'
-            : 'Select a zone to manage'}
+          {validSelectedZone
+            ? `Managing ${validSelectedZone}`
+            : !selectedKey
+              ? 'Select a zone and a matching key is chosen automatically'
+              : 'Select a zone to manage'}
         </FormHelperText>
       </FormControl>
 

--- a/src/components/ZoneEditor.tsx
+++ b/src/components/ZoneEditor.tsx
@@ -778,7 +778,7 @@ function ZoneEditor() {
                       Value
                     </TableSortLabel>
                   </TableCell>
-                  <TableCell>
+                  <TableCell sx={{ display: { xs: 'none', sm: 'table-cell' } }}>
                     <TableSortLabel
                       active={orderBy === 'ttl'}
                       direction={orderBy === 'ttl' ? order : 'asc'}
@@ -848,7 +848,7 @@ function ZoneEditor() {
                           )}
                         </Box>
                       </TableCell>
-                      <TableCell>{record.ttl}</TableCell>
+                      <TableCell sx={{ display: { xs: 'none', sm: 'table-cell' } }}>{record.ttl}</TableCell>
                       <TableCell align="right">
                         <Box component="span" sx={{ display: 'inline-flex', gap: 1 }}>
                           {record.type !== 'SOA' && (

--- a/src/components/ZoneEditor.tsx
+++ b/src/components/ZoneEditor.tsx
@@ -655,18 +655,19 @@ function ZoneEditor() {
         </FormControl>
 
         <Tooltip title="Refresh Records">
-          <IconButton
-            onClick={loadZoneRecords}
-            disabled={!selectedZone || !selectedKey || refreshing}
-            size="small"
-            sx={{ alignSelf: 'center' }}
-          >
-            {refreshing ? (
-              <CircularProgress size={20} />
-            ) : (
-              <RefreshIcon />
-            )}
-          </IconButton>
+          <span style={{ alignSelf: 'center' }}>
+            <IconButton
+              onClick={loadZoneRecords}
+              disabled={!selectedZone || !selectedKey || refreshing}
+              size="small"
+            >
+              {refreshing ? (
+                <CircularProgress size={20} />
+              ) : (
+                <RefreshIcon />
+              )}
+            </IconButton>
+          </span>
         </Tooltip>
       </Box>
 


### PR DESCRIPTION
## Summary

Three cosmetic issues from the QA walkthrough:

- **MUI "disabled button in Tooltip" console spam** on every page — fixed all three cases (AuditLog refresh/export, ZoneEditor refresh) by wrapping the disabled button in a `<span>` per MUI's documented fix. Grepped the whole tree; Snapshots' tooltips wrap non-disabled elements, so nothing there needed changing.
- **Stale zone-selector helper text** — "Select a zone to manage" persisted after selection; now shows "Managing <zone>" when a zone is chosen and only shows the guidance when none is.
- **Mobile record-table actions off-screen** — at ~390px the edit/delete column was pushed past the edge; the TTL column is now hidden below `sm` (it's still shown in the edit dialog), freeing width so row actions stay reachable. Desktop renders identically.

## Testing

`tsc` clean; 225 tests green; no new eslint warnings.