### PR TITLE
fix(security): rate limiting and secure cookies default-on, not NODE_ENV-gated

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,16 @@ ALLOWED_ORIGINS=http://localhost:3001,https://snap-dns.domain.com
 NODE_ENV=development
 MAX_REQUEST_SIZE=10mb
 
+# Security toggles (default to SECURE; independent of NODE_ENV)
+# COOKIE_SECURE: session cookie is Secure (HTTPS-only) unless set to false.
+#   A Secure cookie is NOT sent over plain HTTP, so for local HTTP dev you MUST
+#   set COOKIE_SECURE=false or login sessions will not persist. Leave unset
+#   (defaults to true) for any HTTPS deployment.
+COOKIE_SECURE=false
+# RATE_LIMIT_ENABLED: API/login rate limiting is ON unless set to false.
+#   Disable only for local dev / tests that fire many requests.
+RATE_LIMIT_ENABLED=false
+
 # Session Secret - CHANGE THIS IN PRODUCTION!
 # Generate with: openssl rand -base64 32
 SESSION_SECRET=change-this-to-a-random-secret-in-production

--- a/.env.production.example
+++ b/.env.production.example
@@ -30,6 +30,13 @@ REACT_APP_API_URL=http://localhost:3002
 #   http://your-server-ip:3001  or  https://snap-dns.example.com
 ALLOWED_ORIGINS=http://localhost:3001
 
+# ── Security toggles (default to SECURE; leave unset in production) ──
+# Both controls default to ON and are independent of NODE_ENV, so a prod
+# deployment stays protected even if NODE_ENV is misconfigured. Only set these
+# to opt OUT — do NOT set them here for a normal HTTPS production deployment.
+#   COOKIE_SECURE=true        # Secure (HTTPS-only) session cookie (default)
+#   RATE_LIMIT_ENABLED=true   # API/login brute-force protection (default)
+
 # ── Optional tuning (sensible defaults applied if omitted) ───────────
 # MAX_REQUEST_SIZE=10mb
 # MAX_ZONE_RECORDS=10000

--- a/.env.test.example
+++ b/.env.test.example
@@ -14,3 +14,10 @@ ALLOWED_ORIGINS=http://${FRONTEND_HOST}:3001
 # Optional: Change ports if needed
 # FRONTEND_PORT=3001
 # BACKEND_PORT=3002
+
+# Security toggles (default to SECURE). The test stack runs over plain HTTP and
+# fires many requests, so opt out of both explicitly:
+#   COOKIE_SECURE=false  (Secure cookies are not sent over http://)
+#   RATE_LIMIT_ENABLED=false  (don't throttle test traffic)
+COOKIE_SECURE=false
+RATE_LIMIT_ENABLED=false

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -6,4 +6,7 @@ module.exports = {
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.test.ts', '**/?(*.)+(spec|test).ts'],
   clearMocks: true,
+  // Force the explicit security opt-outs for tests (see jest.setup.js) instead of
+  // weakening the secure-by-default toggles in config/securityToggles.ts.
+  setupFiles: ['<rootDir>/jest.setup.js'],
 };

--- a/backend/jest.setup.js
+++ b/backend/jest.setup.js
@@ -1,0 +1,11 @@
+// backend/jest.setup.js
+// Test-environment security-toggle overrides.
+//
+// The application defaults to SECURE (rate limiting on, cookies Secure) so that
+// a production deployment that forgets NODE_ENV=production is not silently
+// insecure. The test suite legitimately needs those toggles off: HTTP-level
+// tests may fire many requests (which real rate limits would throttle) and run
+// over plain HTTP. We set the explicit opt-out here rather than weakening the
+// default so the secure default remains in force everywhere else.
+process.env.RATE_LIMIT_ENABLED = 'false';
+process.env.COOKIE_SECURE = 'false';

--- a/backend/src/config/__tests__/securityToggles.test.ts
+++ b/backend/src/config/__tests__/securityToggles.test.ts
@@ -1,0 +1,66 @@
+// backend/src/config/__tests__/securityToggles.test.ts
+import {
+  resolveBooleanEnv,
+  isRateLimitEnabled,
+  isCookieSecure,
+} from '../securityToggles';
+
+describe('resolveBooleanEnv', () => {
+  it('returns the default when unset or empty', () => {
+    expect(resolveBooleanEnv(undefined, true)).toBe(true);
+    expect(resolveBooleanEnv(undefined, false)).toBe(false);
+    expect(resolveBooleanEnv('', true)).toBe(true);
+    expect(resolveBooleanEnv('   ', true)).toBe(true);
+  });
+
+  it('treats false-like values as false regardless of default', () => {
+    for (const v of ['false', 'FALSE', '0', 'no', 'off', ' Off ']) {
+      expect(resolveBooleanEnv(v, true)).toBe(false);
+    }
+  });
+
+  it('treats true-like values as true regardless of default', () => {
+    for (const v of ['true', 'TRUE', '1', 'yes', 'on', ' On ']) {
+      expect(resolveBooleanEnv(v, false)).toBe(true);
+    }
+  });
+
+  it('falls back to the default for unrecognized values', () => {
+    expect(resolveBooleanEnv('maybe', true)).toBe(true);
+    expect(resolveBooleanEnv('maybe', false)).toBe(false);
+  });
+});
+
+describe('isRateLimitEnabled', () => {
+  it('defaults to enabled (secure) when unset, regardless of NODE_ENV', () => {
+    expect(isRateLimitEnabled({})).toBe(true);
+    expect(isRateLimitEnabled({ NODE_ENV: 'development' })).toBe(true);
+    expect(isRateLimitEnabled({ NODE_ENV: 'test' })).toBe(true);
+    expect(isRateLimitEnabled({ NODE_ENV: 'production' })).toBe(true);
+  });
+
+  it('honors an explicit opt-out', () => {
+    expect(isRateLimitEnabled({ RATE_LIMIT_ENABLED: 'false' })).toBe(false);
+    expect(isRateLimitEnabled({ RATE_LIMIT_ENABLED: '0' })).toBe(false);
+  });
+
+  it('stays on for an explicit true', () => {
+    expect(isRateLimitEnabled({ RATE_LIMIT_ENABLED: 'true' })).toBe(true);
+  });
+});
+
+describe('isCookieSecure', () => {
+  it('defaults to secure when unset, regardless of NODE_ENV', () => {
+    expect(isCookieSecure({})).toBe(true);
+    expect(isCookieSecure({ NODE_ENV: 'development' })).toBe(true);
+    expect(isCookieSecure({ NODE_ENV: 'production' })).toBe(true);
+  });
+
+  it('honors an explicit opt-out for local HTTP dev', () => {
+    expect(isCookieSecure({ COOKIE_SECURE: 'false' })).toBe(false);
+  });
+
+  it('stays secure for an explicit true', () => {
+    expect(isCookieSecure({ COOKIE_SECURE: 'true' })).toBe(true);
+  });
+});

--- a/backend/src/config/securityToggles.ts
+++ b/backend/src/config/securityToggles.ts
@@ -1,0 +1,55 @@
+// backend/src/config/securityToggles.ts
+// Explicit, default-secure toggles for security controls that were previously
+// driven implicitly by NODE_ENV.
+//
+// The prior design silently disabled brute-force protection and secure cookies
+// whenever NODE_ENV was not exactly 'production' -- and NODE_ENV defaults to
+// 'development'. A production deployment that forgot to set NODE_ENV=production
+// therefore ran with NO login rate limiting and NON-secure cookies.
+//
+// These toggles instead DEFAULT TO SECURE and require an explicit opt-out:
+//   - RATE_LIMIT_ENABLED=false  disables rate limiting (for tests / local dev
+//                               that legitimately fire many requests)
+//   - COOKIE_SECURE=false       marks the session cookie non-Secure so it is
+//                               sent over plain HTTP (for local HTTP dev)
+// With no env set, both are ON regardless of NODE_ENV.
+
+/**
+ * Parse a boolean-ish env var. An unset/empty value yields `defaultValue`.
+ * Only an explicit, case-insensitive false-like value ("false"/"0"/"no"/"off")
+ * turns the control off; true-like values force it on; anything else falls back
+ * to `defaultValue`.
+ */
+export function resolveBooleanEnv(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined) {
+    return defaultValue;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === '') {
+    return defaultValue;
+  }
+  if (['false', '0', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+  if (['true', '1', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  return defaultValue;
+}
+
+/**
+ * Whether API/login rate limiting is active. Default: ON (secure).
+ * Set RATE_LIMIT_ENABLED=false to disable (tests / high-volume local dev).
+ */
+export function isRateLimitEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return resolveBooleanEnv(env.RATE_LIMIT_ENABLED, true);
+}
+
+/**
+ * Whether the session cookie is marked Secure (HTTPS-only). Default: ON (secure).
+ * Set COOKIE_SECURE=false for local HTTP dev, otherwise the browser will not send
+ * the cookie over plain HTTP and login will appear to "not persist".
+ */
+export function isCookieSecure(env: NodeJS.ProcessEnv = process.env): boolean {
+  return resolveBooleanEnv(env.COOKIE_SECURE, true);
+}

--- a/backend/src/middleware/rateLimiter.ts
+++ b/backend/src/middleware/rateLimiter.ts
@@ -2,9 +2,12 @@
 // Rate limiting middleware for DNS operations and API endpoints
 
 import { rateLimit } from 'express-rate-limit';
+import { isRateLimitEnabled } from '../config/securityToggles';
 
-// Skip rate limiting in test/development environments
-const isTestOrDev = process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development';
+// Rate limiting is ON by default (secure) and only skipped when explicitly
+// disabled via RATE_LIMIT_ENABLED=false -- not based on NODE_ENV. See
+// config/securityToggles.ts for the rationale.
+const rateLimitDisabled = !isRateLimitEnabled();
 
 /**
  * Rate limiter for DNS zone queries (GET operations)
@@ -20,9 +23,9 @@ export const dnsQueryLimiter = rateLimit({
   },
   standardHeaders: true,
   legacyHeaders: false,
-  // Skip rate limiting in test/dev environments
+  // Skip only when rate limiting is explicitly disabled (default: enabled)
   skip: (_req) => {
-    return isTestOrDev;
+    return rateLimitDisabled;
   }
 });
 
@@ -40,9 +43,9 @@ export const dnsModifyLimiter = rateLimit({
   },
   standardHeaders: true,
   legacyHeaders: false,
-  // Skip rate limiting in test/dev environments
+  // Skip only when rate limiting is explicitly disabled (default: enabled)
   skip: (_req) => {
-    return isTestOrDev;
+    return rateLimitDisabled;
   },
   // Use user ID as key for authenticated requests
   keyGenerator: (req) => {
@@ -69,9 +72,9 @@ export const keyManagementLimiter = rateLimit({
   },
   standardHeaders: true,
   legacyHeaders: false,
-  // Skip rate limiting in test/dev environments
+  // Skip only when rate limiting is explicitly disabled (default: enabled)
   skip: (_req) => {
-    return isTestOrDev;
+    return rateLimitDisabled;
   },
   keyGenerator: (req) => {
     if (req.session?.userId) {
@@ -95,9 +98,9 @@ export const webhookLimiter = rateLimit({
   },
   standardHeaders: true,
   legacyHeaders: false,
-  // Skip rate limiting in test/dev environments
+  // Skip only when rate limiting is explicitly disabled (default: enabled)
   skip: (_req) => {
-    return isTestOrDev;
+    return rateLimitDisabled;
   },
   keyGenerator: (req) => {
     if (req.session?.userId) {
@@ -121,8 +124,8 @@ export const generalApiLimiter = rateLimit({
   },
   standardHeaders: true,
   legacyHeaders: false,
-  // Skip rate limiting in test/dev environments
+  // Skip only when rate limiting is explicitly disabled (default: enabled)
   skip: (_req) => {
-    return isTestOrDev;
+    return rateLimitDisabled;
   }
 });

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -1,6 +1,7 @@
 // backend/src/routes/authRoutes.ts
 import { Router, Request, Response } from 'express';
 import { rateLimit } from 'express-rate-limit';
+import { isRateLimitEnabled } from '../config/securityToggles';
 import { userService } from '../services/userService';
 import { auditService, AuditEventType } from '../services/auditService';
 import { requireAuth, requireRole } from '../middleware/auth';
@@ -22,9 +23,10 @@ const loginLimiter = rateLimit({
   },
   standardHeaders: true,
   legacyHeaders: false,
-  // Skip rate limiting in test/dev environments
+  // Skip only when rate limiting is explicitly disabled (default: enabled).
+  // Brute-force protection stays ON regardless of NODE_ENV.
   skip: (_req) => {
-    return process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development';
+    return !isRateLimitEnabled();
   }
 });
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -25,6 +25,7 @@ import ssoConfigRoutes from './routes/ssoConfigRoutes';
 import auditRoutes from './routes/auditRoutes';
 import { config } from './config';
 import { resolveSessionSecret } from './config/secrets';
+import { isCookieSecure } from './config/securityToggles';
 import { readFileSync } from 'fs';
 
 // Application version, read from package.json (present next to dist/ at runtime).
@@ -99,7 +100,10 @@ app.use(session({
   name: 'snap-dns.sid',
   cookie: {
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production', // HTTPS only in production
+    // Secure (HTTPS-only) by default; opt out with COOKIE_SECURE=false for local
+    // HTTP dev. A Secure cookie is NOT sent over plain HTTP, so leaving this ON
+    // while serving over http:// makes the session appear not to persist.
+    secure: isCookieSecure(),
     sameSite: 'lax',
     maxAge: 24 * 60 * 60 * 1000 // 24 hours
   }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -59,6 +59,11 @@ services:
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost:3001}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3001,http://10.100.0.30:3001}
       - SESSION_SECRET=test-secret-do-not-use-in-production
+      # Test stack runs over plain HTTP: a Secure cookie is never sent by the
+      # browser, so opt out explicitly. Security controls default to ON.
+      - COOKIE_SECURE=false
+      # Don't throttle the test/integration stack.
+      - RATE_LIMIT_ENABLED=false
       - TEMP_DIR=/tmp/snap-dns
       - MAX_ZONE_RECORDS=10000
       - ZONE_RECORDS_WARNING_THRESHOLD=5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,11 @@ services:
       - NODE_ENV=development
       - BACKEND_HOST=0.0.0.0
       - BACKEND_PORT=3002
+      # Local dev is served over plain HTTP: a Secure cookie would never be sent
+      # by the browser, so opt out explicitly. Security controls default to ON.
+      - COOKIE_SECURE=false
+      # Don't throttle local dev (many rapid requests during development).
+      - RATE_LIMIT_ENABLED=false
     command: npm run dev
     cap_add:
       - NET_RAW

--- a/test/backend/.env.test
+++ b/test/backend/.env.test
@@ -10,6 +10,11 @@ NODE_ENV=test
 # CORS Configuration
 ALLOWED_ORIGINS=http://localhost:3001,http://10.100.0.30:3001
 
+# Security toggles default to SECURE; the test stack runs over plain HTTP and
+# fires many requests, so opt out of both explicitly (DO NOT do this in prod).
+COOKIE_SECURE=false
+RATE_LIMIT_ENABLED=false
+
 # Session Secret (DO NOT use in production!)
 SESSION_SECRET=test-secret-do-not-use-in-production-change-this-value
 


### PR DESCRIPTION
## Summary

Confirmed hygiene finding: brute-force protection and secure cookies were silently disabled whenever `NODE_ENV !== 'production'` — and `NODE_ENV` defaults to `'development'`, so a prod deployment that forgot to set it ran with no login rate limiting and non-secure cookies.

Replaced the implicit NODE_ENV checks with explicit, default-secure toggles (new `backend/src/config/securityToggles.ts`, matching the `secrets.ts` fail-fast pattern):

- **`RATE_LIMIT_ENABLED`** — default ON; only an explicit false-like value disables. Replaces the NODE_ENV `skip` predicates in `rateLimiter.ts` (5 limiters) and the login limiter in `authRoutes.ts`.
- **`COOKIE_SECURE`** — default ON; explicit `COOKIE_SECURE=false` opts out for local HTTP dev. Replaces `secure: NODE_ENV === 'production'` in `server.ts`. (`sameSite: 'lax'` was already hardcoded, left as-is.)

With no env set, both are on regardless of NODE_ENV. Dev and test compose files (and `.env.test`) set both to `false` so local/CI runs work over plain HTTP; `.env.example`/`.env.production.example` document the trade-off (a Secure cookie isn't sent over http://).

## Testing

Tests kept green by adding `jest.setup.js` that sets both toggles off for the suite (forward-proofing future HTTP tests) rather than weakening the default. New `securityToggles.test.ts` covers default-on/secure across NODE_ENV values and explicit opt-in/opt-out. Backend 245 tests green; lint clean on changed files; build clean.