### PR TITLE
fix(audit): cover snapshot, config, TSIG-key, and DNS-update events

### DIFF
--- a/backend/src/routes/backupRoutes.ts
+++ b/backend/src/routes/backupRoutes.ts
@@ -3,6 +3,7 @@ import { Router, Request, Response } from 'express';
 import { requireAuth, requireWriteAccess } from '../middleware/auth';
 import { AuthenticatedRequest } from '../types/auth';
 import { backupService } from '../services/backupService';
+import { auditService, AuditEventType } from '../services/auditService';
 
 const router = Router();
 
@@ -141,6 +142,20 @@ router.post('/zone/:zone', requireAuth, requireWriteAccess, async (req: Request,
       description,
     });
 
+    // Audit the snapshot lifecycle. Record counts/metadata only - never record values.
+    await auditService.log(AuditEventType.SNAPSHOT_CREATED, {
+      userId: user.userId,
+      username: user.username,
+      success: true,
+      details: {
+        zone,
+        snapshotId: backup.id,
+        type: backup.type,
+        description: backup.description,
+        recordCount: Array.isArray(records) ? records.length : 0,
+      },
+    });
+
     res.status(201).json({
       success: true,
       backup,
@@ -165,6 +180,17 @@ router.delete('/zone/:zone/:backupId', requireAuth, async (req: Request, res: Re
     const { zone, backupId } = req.params;
 
     await backupService.deleteBackup(zone, backupId, user.userId, user.role);
+
+    // Audit the snapshot deletion.
+    await auditService.log(AuditEventType.SNAPSHOT_DELETED, {
+      userId: user.userId,
+      username: user.username,
+      success: true,
+      details: {
+        zone,
+        snapshotId: backupId,
+      },
+    });
 
     res.json({
       success: true,

--- a/backend/src/routes/ssoConfigRoutes.ts
+++ b/backend/src/routes/ssoConfigRoutes.ts
@@ -79,12 +79,11 @@ router.put('/', requireAuth, requireRole(UserRole.ADMIN), async (req: Request, r
     await ssoConfigService.updateConfig(updates);
 
     // Log configuration change
-    await auditService.log(AuditEventType.USER_UPDATED, {
+    await auditService.log(AuditEventType.SSO_CONFIG_UPDATED, {
       userId: req.session.userId,
       username: req.session.username,
       success: true,
       details: {
-        action: 'sso_config_updated',
         enabled: updates.enabled,
         provider: updates.provider,
       },

--- a/backend/src/routes/tsigKeyRoutes.ts
+++ b/backend/src/routes/tsigKeyRoutes.ts
@@ -5,6 +5,7 @@ import { AuthenticatedRequest, UserRole } from '../types/auth';
 import { tsigKeyService, TSIGKeyCreate } from '../services/tsigKeyService';
 import { keyManagementLimiter } from '../middleware/rateLimiter';
 import { validateTSIGKeyCreate, validateTSIGKeyUpdate } from '../middleware/validation';
+import { auditService, AuditEventType } from '../services/auditService';
 
 const router = Router();
 
@@ -59,6 +60,17 @@ router.post('/', requireAuth, requireWriteAccess, validateTSIGKeyCreate, async (
     }
 
     const key = await tsigKeyService.createKey(user.userId, keyData);
+
+    // Audit key creation. Never log the key value/secret - only identifying metadata.
+    await auditService.log(AuditEventType.KEY_CREATED, {
+      userId: user.userId,
+      username: user.username,
+      success: true,
+      details: {
+        keyId: key.id,
+        name: key.name,
+      },
+    });
 
     res.status(201).json({
       success: true,
@@ -140,6 +152,17 @@ router.put('/:keyId', requireAuth, requireWriteAccess, validateTSIGKeyUpdate, as
     const updates: Partial<TSIGKeyCreate> = req.body;
     const key = await tsigKeyService.updateKey(keyId, updates);
 
+    // Audit key update. Never log the key value/secret - only identifying metadata.
+    await auditService.log(AuditEventType.KEY_UPDATED, {
+      userId: user.userId,
+      username: user.username,
+      success: true,
+      details: {
+        keyId: key.id,
+        name: key.name,
+      },
+    });
+
     res.json({
       success: true,
       key,
@@ -168,9 +191,21 @@ router.put('/:keyId', requireAuth, requireWriteAccess, validateTSIGKeyUpdate, as
  */
 router.delete('/:keyId', requireAuth, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
   try {
+    const authReq = req as AuthenticatedRequest;
+    const user = authReq.user!;
     const { keyId } = req.params;
 
     await tsigKeyService.deleteKey(keyId);
+
+    // Audit key deletion.
+    await auditService.log(AuditEventType.KEY_DELETED, {
+      userId: user.userId,
+      username: user.username,
+      success: true,
+      details: {
+        keyId,
+      },
+    });
 
     res.json({
       success: true,

--- a/backend/src/routes/webhookConfigRoutes.ts
+++ b/backend/src/routes/webhookConfigRoutes.ts
@@ -3,6 +3,7 @@ import { Router, Request, Response } from 'express';
 import { requireAuth, requireRole } from '../middleware/auth';
 import { AuthenticatedRequest, UserRole } from '../types/auth';
 import { webhookConfigService } from '../services/webhookConfigService';
+import { auditService, AuditEventType } from '../services/auditService';
 
 const router = Router();
 
@@ -85,6 +86,19 @@ router.put('/', requireAuth, async (req: Request, res: Response) => {
       enabled !== undefined ? enabled : true
     );
 
+    // Audit the config change. Never log the webhook URL (may embed a secret
+    // token); record only the provider, enabled state, and whether a URL is set.
+    await auditService.log(AuditEventType.WEBHOOK_CONFIG_UPDATED, {
+      userId: user.userId,
+      username: user.username,
+      success: true,
+      details: {
+        provider: config.webhookProvider,
+        enabled: config.enabled,
+        hasUrl: Boolean(config.webhookUrl),
+      },
+    });
+
     // Don't send userId back to client
     const { userId: _userId, ...configWithoutUserId } = config;
 
@@ -111,6 +125,14 @@ router.delete('/', requireAuth, async (req: Request, res: Response) => {
     const user = authReq.user!;
 
     await webhookConfigService.deleteConfig(user.userId);
+
+    // Audit the config deletion.
+    await auditService.log(AuditEventType.WEBHOOK_CONFIG_DELETED, {
+      userId: user.userId,
+      username: user.username,
+      success: true,
+      details: {},
+    });
 
     res.json({
       success: true,

--- a/backend/src/routes/zoneRoutes.ts
+++ b/backend/src/routes/zoneRoutes.ts
@@ -436,11 +436,13 @@ router.patch(
     // Use atomic update operation
     const result = await dnsService.updateRecord(zone, oldRecord, newRecord, keyConfig);
 
-    // Log successful DNS operation
+    // Log successful DNS operation. Pass the new record (not a {old,new}
+    // wrapper) so the audit entry carries the record name/type and a correct
+    // valueLength, consistent with the add/delete entries.
     await auditService.logDNSOperation(
       'update',
       zone,
-      { old: oldRecord, new: newRecord },
+      newRecord,
       user.userId,
       user.username,
       true
@@ -573,7 +575,9 @@ router.post(
     // failed (which would prompt a confusing re-apply).
     try {
       for (const change of changes) {
-        const record = change.op === 'update' ? { old: change.oldRecord, new: change.newRecord } : change.record;
+        // For updates, audit the new record so the entry carries name/type/
+        // valueLength (a {old,new} wrapper would log valueLength:0 with no name).
+        const record = change.op === 'update' ? change.newRecord : change.record;
         await auditService.logDNSOperation(change.op, zone, record, user.userId, user.username, true);
       }
     } catch (auditErr) {

--- a/backend/src/services/__tests__/auditService.test.ts
+++ b/backend/src/services/__tests__/auditService.test.ts
@@ -1,0 +1,115 @@
+// backend/src/services/__tests__/auditService.test.ts
+// Unit tests for the audit service: verifies the DNS-operation payload shape
+// (name/type/valueLength, with value redacted) and the newly added event types.
+import { auditService, AuditEventType, AuditEntry } from '../auditService';
+
+describe('auditService', () => {
+  // Capture the entries the service would persist without touching the real
+  // audit.log file. writeEntry is private, so we spy through an any-cast.
+  function captureEntries(): AuditEntry[] {
+    const entries: AuditEntry[] = [];
+    jest
+      .spyOn(auditService as unknown as { writeEntry: (e: AuditEntry) => Promise<void> }, 'writeEntry')
+      .mockImplementation(async (entry: AuditEntry) => {
+        entries.push(entry);
+      });
+    return entries;
+  }
+
+  async function flush(): Promise<void> {
+    // The service serializes writes through an internal queue; awaiting it
+    // guarantees the mocked writeEntry has run for all pending log() calls.
+    await (auditService as unknown as { writeQueue: Promise<void> }).writeQueue;
+  }
+
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(jest.fn());
+    jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('new event types', () => {
+    it('exposes snapshot and config lifecycle event types', () => {
+      expect(AuditEventType.SNAPSHOT_CREATED).toBe('snapshot.created');
+      expect(AuditEventType.SNAPSHOT_DELETED).toBe('snapshot.deleted');
+      expect(AuditEventType.WEBHOOK_CONFIG_UPDATED).toBe('config.webhook.updated');
+      expect(AuditEventType.WEBHOOK_CONFIG_DELETED).toBe('config.webhook.deleted');
+      expect(AuditEventType.SSO_CONFIG_UPDATED).toBe('config.sso.updated');
+    });
+
+    it('persists a snapshot-created entry with zone and snapshot metadata', async () => {
+      const entries = captureEntries();
+
+      await auditService.log(AuditEventType.SNAPSHOT_CREATED, {
+        userId: 'u1',
+        username: 'admin',
+        success: true,
+        details: { zone: 'test.local', snapshotId: 'snap-1', recordCount: 3 },
+      });
+      await flush();
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].eventType).toBe(AuditEventType.SNAPSHOT_CREATED);
+      expect(entries[0].details).toEqual({
+        zone: 'test.local',
+        snapshotId: 'snap-1',
+        recordCount: 3,
+      });
+      expect(entries[0].timestamp).toEqual(expect.any(String));
+    });
+  });
+
+  describe('logDNSOperation payload', () => {
+    it('records name/type/valueLength for an update without leaking the value', async () => {
+      const entries = captureEntries();
+      const newRecord = { name: 'www.test.local', type: 'A', value: '192.0.2.10' };
+
+      await auditService.logDNSOperation('update', 'test.local', newRecord, 'u1', 'admin', true);
+      await flush();
+
+      expect(entries).toHaveLength(1);
+      const entry = entries[0];
+      expect(entry.eventType).toBe(AuditEventType.RECORD_UPDATED);
+      expect(entry.details.zone).toBe('test.local');
+      expect(entry.details.record).toEqual({
+        name: 'www.test.local',
+        type: 'A',
+        valueLength: '192.0.2.10'.length,
+      });
+      // Redaction: the raw value must never appear in the persisted entry.
+      expect(JSON.stringify(entry)).not.toContain('192.0.2.10');
+    });
+
+    it('produces the same payload shape for add, delete, and update', async () => {
+      const entries = captureEntries();
+      const record = { name: 'mail.test.local', type: 'MX', value: '10 mx.test.local' };
+
+      await auditService.logDNSOperation('add', 'test.local', record, 'u1', 'admin', true);
+      await auditService.logDNSOperation('delete', 'test.local', record, 'u1', 'admin', true);
+      await auditService.logDNSOperation('update', 'test.local', record, 'u1', 'admin', true);
+      await flush();
+
+      const shapes = entries.map((e) => e.details.record);
+      for (const shape of shapes) {
+        expect(shape).toEqual({
+          name: 'mail.test.local',
+          type: 'MX',
+          valueLength: '10 mx.test.local'.length,
+        });
+      }
+    });
+
+    it('reports valueLength 0 when the record has no string value', async () => {
+      const entries = captureEntries();
+      const record = { name: 'test.local', type: 'A' };
+
+      await auditService.logDNSOperation('add', 'test.local', record, 'u1', 'admin', true);
+      await flush();
+
+      expect(entries[0].details.record.valueLength).toBe(0);
+    });
+  });
+});

--- a/backend/src/services/auditService.ts
+++ b/backend/src/services/auditService.ts
@@ -31,6 +31,15 @@ export enum AuditEventType {
   RECORD_UPDATED = 'dns.record.updated',
   ZONE_QUERIED = 'dns.zone.queried',
 
+  // Snapshot (server-side zone backup) lifecycle
+  SNAPSHOT_CREATED = 'snapshot.created',
+  SNAPSHOT_DELETED = 'snapshot.deleted',
+
+  // Server-side configuration changes
+  WEBHOOK_CONFIG_UPDATED = 'config.webhook.updated',
+  WEBHOOK_CONFIG_DELETED = 'config.webhook.deleted',
+  SSO_CONFIG_UPDATED = 'config.sso.updated',
+
   // Security events
   UNAUTHORIZED_ACCESS = 'security.unauthorized',
   VALIDATION_FAILURE = 'security.validation_failure',


### PR DESCRIPTION
## Summary

Live QA found audit-logging gaps; investigating them turned up more than the walkthrough saw:

- **Snapshot lifecycle** was entirely unaudited → `SNAPSHOT_CREATED` (zone, id, type, recordCount) and `SNAPSHOT_DELETED` in `backupRoutes`. (No server-side restore endpoint — restore applies through the already-audited zone batch path, so no separate event.)
- **Server-side config changes**: `WEBHOOK_CONFIG_UPDATED/DELETED` (URL never logged — it can embed a secret), and `SSO_CONFIG_UPDATED` (was mislabeled as the generic `USER_UPDATED`).
- **TSIG key events** had enum values but were never wired — now `KEY_CREATED/UPDATED/DELETED` fire in `tsigKeyRoutes` (id + friendly name only, never the key value).
- **`RECORD_UPDATED` payload bug**: both update paths passed a `{old, new}` wrapper to `logDNSOperation`, which reads `record.name/type/value.length` — so update entries logged `{valueLength: 0}` with no name. Now passes the new record directly; update entries match add/delete shape. Redaction preserved (only `valueLength`, never the value).

Note: frontend-only settings (default TTL, rows-per-page) live in browser localStorage and can't be backend-audited — out of scope by design.

## Testing

New `auditService.test.ts` (5 tests): new event constants, a persisted snapshot entry, and the DNS-operation payload contract (update carries name/type/valueLength; raw value absent from the serialized entry; identical shape across add/delete/update). Backend 240 tests green; lint clean; build clean. No supertest infra exists, so handler→audit wiring is covered by review + the type-checked build rather than an HTTP test (noted).