### PR TITLE
fix(auth): constant-time login to prevent username enumeration

### DIFF
--- a/backend/src/services/__tests__/userService.timing.test.ts
+++ b/backend/src/services/__tests__/userService.timing.test.ts
@@ -1,0 +1,79 @@
+// backend/src/services/__tests__/userService.timing.test.ts
+// Verifies that authenticate() is constant-time with respect to username
+// existence: an unknown username must still perform a bcrypt comparison (against
+// a dummy hash) rather than returning early, so login timing cannot be used to
+// enumerate valid usernames. Also confirms the known-user paths still behave.
+import bcrypt from 'bcrypt';
+import { userService } from '../userService';
+import { User, UserRole } from '../../types/auth';
+
+describe('userService.authenticate timing safety', () => {
+  const KNOWN_USERNAME = 'alice';
+  const KNOWN_PASSWORD = 'correct horse battery staple';
+  let knownUser: User;
+
+  beforeEach(async () => {
+    jest.spyOn(console, 'log').mockImplementation(jest.fn());
+    jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+
+    // Avoid touching disk / triggering the default-admin bootstrap.
+    jest
+      .spyOn(userService as unknown as { initialize: () => Promise<void> }, 'initialize')
+      .mockResolvedValue(undefined);
+    jest
+      .spyOn(userService as unknown as { saveUsers: () => Promise<void> }, 'saveUsers')
+      .mockResolvedValue(undefined);
+
+    // Mark as initialized and seed a single known user directly into the map.
+    (userService as unknown as { initialized: boolean }).initialized = true;
+    const users: Map<string, User> = (userService as unknown as { users: Map<string, User> }).users;
+    users.clear();
+    knownUser = {
+      id: 'user_test_1',
+      username: KNOWN_USERNAME,
+      passwordHash: await bcrypt.hash(KNOWN_PASSWORD, 12),
+      role: UserRole.ADMIN,
+      email: 'alice@localhost',
+      createdAt: new Date(),
+      allowedKeyIds: [],
+      allowedZones: [],
+    };
+    users.set(knownUser.id, knownUser);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    (userService as unknown as { users: Map<string, User> }).users.clear();
+    (userService as unknown as { initialized: boolean }).initialized = false;
+  });
+
+  it('performs a bcrypt comparison for an unknown username (no early return)', async () => {
+    const compareSpy = jest.spyOn(bcrypt, 'compare');
+
+    const result = await userService.authenticate('does-not-exist', 'whatever');
+
+    // Unknown username fails, identically to a wrong password.
+    expect(result).toBeNull();
+    // The oracle-closing property: a bcrypt comparison ran even though the user
+    // was not found, so this path is not a trivially-early return.
+    expect(compareSpy).toHaveBeenCalledTimes(1);
+    // It compared the supplied password (against the internal dummy hash).
+    expect(compareSpy.mock.calls[0][0]).toBe('whatever');
+  });
+
+  it('returns null for a known username with a wrong password (also runs a compare)', async () => {
+    const compareSpy = jest.spyOn(bcrypt, 'compare');
+
+    const result = await userService.authenticate(KNOWN_USERNAME, 'wrong-password');
+
+    expect(result).toBeNull();
+    expect(compareSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the user for a known username with the correct password', async () => {
+    const result = await userService.authenticate(KNOWN_USERNAME, KNOWN_PASSWORD);
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(knownUser.id);
+  });
+});

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -7,6 +7,14 @@ import { User, UserCreateData, UserResponse, UserRole } from '../types/auth';
 const SALT_ROUNDS = 12;
 const USERS_FILE = path.join(process.cwd(), 'data', 'users.json');
 
+// Precomputed bcrypt hash used only to keep authenticate() timing constant when
+// the supplied username does not exist. Comparing a wrong-username attempt
+// against this dummy hash makes it cost roughly the same as a known-username /
+// wrong-password attempt, so an attacker cannot enumerate valid usernames via
+// response timing. Computed once at module load (not per request) at the same
+// cost factor the app uses for real password hashes.
+const DUMMY_PASSWORD_HASH = bcrypt.hashSync('snap-dns-timing-safety-dummy', SALT_ROUNDS);
+
 class UserService {
   private users: Map<string, User> = new Map();
   private initialized = false;
@@ -164,12 +172,15 @@ class UserService {
       u => u.username.toLowerCase() === username.toLowerCase()
     );
 
-    if (!user) {
-      return null;
-    }
+    // Always perform a bcrypt comparison, even when the username is unknown, so
+    // that an unknown username costs roughly the same as a known username with a
+    // wrong password (constant-time with respect to user existence). This
+    // prevents username enumeration via login response timing. For an unknown
+    // user we compare against a fixed dummy hash and always fail.
+    const passwordHash = user ? user.passwordHash : DUMMY_PASSWORD_HASH;
+    const isValid = await bcrypt.compare(password, passwordHash);
 
-    const isValid = await bcrypt.compare(password, user.passwordHash);
-    if (!isValid) {
+    if (!user || !isValid) {
       return null;
     }
 


### PR DESCRIPTION
## Summary

Low-severity finding: `authenticate()` returned early without a bcrypt compare when the username was unknown, so an unknown username responded measurably faster than a known one with a wrong password — a timing oracle for valid usernames. (Login is rate-limited, so low severity, but a cheap textbook fix.)

`authenticate()` now unconditionally runs `bcrypt.compare`: against the real hash for a known user, against a module-load precomputed dummy hash (cost 12) for an unknown one. Both failure cases return identical `null`; the route returns the same generic 401 and logs the same `LOGIN_FAILURE`, so no found-vs-not-found oracle remains. Success path, hashing, and cost factor unchanged.

## Testing

New `userService.timing.test.ts`: unknown user → `null` and `bcrypt.compare` still called (proves no early return); wrong password → `null`; correct → user. Backend 253 tests green; lint clean; build clean.