### PR TITLE
fix(sso): verify id-token claims and move OAuth state to session store

### DIFF
--- a/backend/src/routes/ssoAuthRoutes.ts
+++ b/backend/src/routes/ssoAuthRoutes.ts
@@ -8,24 +8,12 @@ import { auditService, AuditEventType } from '../services/auditService';
 import { UserRole } from '../types/auth';
 import { getClientIp } from '../helpers/ipHelpers';
 import { regenerateSession } from '../helpers/session';
+import { putState, consumeState, SSOStateError } from '../services/ssoStateStore';
 
 const router = Router();
 
 // Frontend base URL for post-SSO redirects.
 const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:3001';
-
-// Store for CSRF state tokens (in production, use Redis)
-const stateStore = new Map<string, { timestamp: number; redirectUri: string }>();
-
-// Clean up old state tokens every 5 minutes
-setInterval(() => {
-  const fiveMinutesAgo = Date.now() - 5 * 60 * 1000;
-  for (const [state, data] of stateStore.entries()) {
-    if (data.timestamp < fiveMinutesAgo) {
-      stateStore.delete(state);
-    }
-  }
-}, 5 * 60 * 1000);
 
 /**
  * GET /api/auth/sso/signin
@@ -43,17 +31,22 @@ router.get('/signin', async (req: Request, res: Response) => {
 
     const redirectUri = ssoConfig.redirectUri || `${req.protocol}://${req.get('host')}/api/auth/sso/callback`;
 
-    // Generate CSRF state token
+    // Generate a CSRF state token and a replay-defending nonce, and stash both
+    // on the browser session (survives restarts / multi-instance; scoped to the
+    // session rather than a process-global map).
     const state = crypto.randomBytes(32).toString('hex');
-    stateStore.set(state, {
+    const nonce = crypto.randomBytes(32).toString('hex');
+    putState(req.session, {
+      state,
+      nonce,
+      redirectUri,
       timestamp: Date.now(),
-      redirectUri: redirectUri
     });
 
     console.log(`SSO sign-in initiated, redirect URI: ${redirectUri}`);
 
-    // Get authorization URL from MSAL
-    const authUrl = await msalService.getAuthCodeUrl(state, redirectUri);
+    // Get authorization URL from MSAL (nonce is embedded in the returned id_token)
+    const authUrl = await msalService.getAuthCodeUrl(state, redirectUri, nonce);
 
     // Redirect user to Microsoft login
     res.redirect(authUrl);
@@ -85,20 +78,22 @@ const handleCallback = async (req: Request, res: Response) => {
       return res.redirect(`${frontendUrl}/login?error=${encodeURIComponent(error)}`);
     }
 
-    // Validate state token (CSRF protection)
-    if (!state || !stateStore.has(state)) {
-      console.error('Invalid or missing state token');
+    // Validate and consume the state token (CSRF protection + single-use). The
+    // pending value is scoped to this browser session and burned on first use.
+    let stateData;
+    try {
+      stateData = consumeState(req.session, state);
+    } catch (err) {
+      const code = err instanceof SSOStateError ? err.code : 'UNKNOWN';
+      console.error(`Invalid SSO state token (${code})`);
       await auditService.log(AuditEventType.UNAUTHORIZED_ACCESS, {
         username: 'unknown',
         success: false,
         ipAddress: getClientIp(req),
-        error: 'Invalid state token',
+        error: `Invalid state token: ${code}`,
       });
       return res.redirect(`${frontendUrl}/login?error=invalid_state`);
     }
-
-    const stateData = stateStore.get(state)!;
-    stateStore.delete(state);
 
     if (!code) {
       console.error('No authorization code received');
@@ -109,9 +104,18 @@ const handleCallback = async (req: Request, res: Response) => {
     console.log('Exchanging authorization code for tokens...');
     const tokenResponse = await msalService.acquireTokenByCode(code, stateData.redirectUri);
 
-    // Decode and validate ID token
-    const claims = msalService.decodeIdToken(tokenResponse.idToken!);
-    console.log('User authenticated:', claims.preferred_username || claims.email);
+    // Use MSAL's validated id_token claims, asserting issuer/audience/expiry and
+    // the nonce we issued at /signin before trusting them to create a session.
+    const claims = await msalService.getValidatedIdTokenClaims(tokenResponse, stateData.nonce);
+
+    // A stable subject (oid) and a resolvable username are required to identify
+    // the user; a token without them is not usable for provisioning.
+    const resolvedUsername = claims.preferred_username || claims.email || claims.upn;
+    if (!claims.oid || !resolvedUsername) {
+      console.error('ID token missing required identity claims (oid/username)');
+      return res.redirect(`${frontendUrl}/login?error=invalid_token`);
+    }
+    console.log('User authenticated:', resolvedUsername);
 
     // Provision or update user (JIT provisioning)
     const userId = `entra_${claims.oid}`;
@@ -123,7 +127,7 @@ const handleCallback = async (req: Request, res: Response) => {
       console.log(`Existing SSO user logged in: ${user.username}`);
     } else {
       // Create new user (JIT provisioning)
-      const username = claims.preferred_username || claims.email || claims.upn;
+      const username = resolvedUsername;
       const email = claims.email || claims.preferred_username;
 
       // Determine role from claims (app roles or default to viewer)

--- a/backend/src/services/__tests__/msalService.validation.test.ts
+++ b/backend/src/services/__tests__/msalService.validation.test.ts
@@ -1,0 +1,126 @@
+// backend/src/services/__tests__/msalService.validation.test.ts
+// Unit tests for validateIdTokenClaims: acceptance of well-formed Entra ID
+// claims and rejection on issuer/audience/expiry/not-before/nonce failures.
+// Pure-function tests — no MSAL client or network involved.
+import { validateIdTokenClaims, ClaimsValidationOptions } from '../msalService';
+import { IdTokenClaims } from '../../types/sso';
+
+const TENANT_ID = '11111111-2222-3333-4444-555555555555';
+const CLIENT_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const NOW = 1_700_000_000; // fixed clock (seconds)
+
+function validClaims(overrides: Partial<IdTokenClaims> = {}): IdTokenClaims {
+  return {
+    iss: `https://login.microsoftonline.com/${TENANT_ID}/v2.0`,
+    aud: CLIENT_ID,
+    exp: NOW + 3600,
+    nbf: NOW - 60,
+    nonce: 'nonce-123',
+    oid: 'user-oid',
+    preferred_username: 'user@example.com',
+    ...overrides,
+  };
+}
+
+function opts(overrides: Partial<ClaimsValidationOptions> = {}): ClaimsValidationOptions {
+  return {
+    tenantId: TENANT_ID,
+    audience: CLIENT_ID,
+    nonce: 'nonce-123',
+    nowSeconds: NOW,
+    ...overrides,
+  };
+}
+
+describe('validateIdTokenClaims — acceptance', () => {
+  it('accepts well-formed claims with matching issuer/audience/expiry/nonce', () => {
+    expect(() => validateIdTokenClaims(validClaims(), opts())).not.toThrow();
+  });
+
+  it('accepts an audience array containing the client id', () => {
+    expect(() =>
+      validateIdTokenClaims(validClaims({ aud: ['other', CLIENT_ID] }), opts())
+    ).not.toThrow();
+  });
+
+  it('accepts a multi-tenant config where iss carries a concrete tenant GUID', () => {
+    const claims = validClaims({
+      iss: `https://login.microsoftonline.com/${TENANT_ID}/v2.0`,
+    });
+    expect(() => validateIdTokenClaims(claims, opts({ tenantId: 'common' }))).not.toThrow();
+  });
+
+  it('does not check nonce when none was issued', () => {
+    const claims = validClaims({ nonce: undefined });
+    expect(() => validateIdTokenClaims(claims, opts({ nonce: undefined }))).not.toThrow();
+  });
+
+  it('tolerates a claim within the allowed clock skew for exp', () => {
+    const claims = validClaims({ exp: NOW - 100 }); // just expired
+    expect(() =>
+      validateIdTokenClaims(claims, opts({ clockSkewSeconds: 300 }))
+    ).not.toThrow();
+  });
+});
+
+describe('validateIdTokenClaims — rejection', () => {
+  it('rejects an issuer for the wrong tenant', () => {
+    const claims = validClaims({
+      iss: 'https://login.microsoftonline.com/99999999-0000-0000-0000-000000000000/v2.0',
+    });
+    expect(() => validateIdTokenClaims(claims, opts())).toThrow(/issuer/i);
+  });
+
+  it('rejects a non-Microsoft issuer', () => {
+    const claims = validClaims({ iss: 'https://evil.example.com/v2.0' });
+    expect(() => validateIdTokenClaims(claims, opts())).toThrow(/issuer/i);
+  });
+
+  it('rejects a missing issuer', () => {
+    const claims = validClaims({ iss: undefined });
+    expect(() => validateIdTokenClaims(claims, opts())).toThrow(/issuer/i);
+  });
+
+  it('rejects a wrong audience', () => {
+    const claims = validClaims({ aud: 'some-other-client' });
+    expect(() => validateIdTokenClaims(claims, opts())).toThrow(/audience/i);
+  });
+
+  it('rejects an audience array without the client id', () => {
+    const claims = validClaims({ aud: ['x', 'y'] });
+    expect(() => validateIdTokenClaims(claims, opts())).toThrow(/audience/i);
+  });
+
+  it('rejects an expired token (beyond clock skew)', () => {
+    const claims = validClaims({ exp: NOW - 1000 });
+    expect(() =>
+      validateIdTokenClaims(claims, opts({ clockSkewSeconds: 300 }))
+    ).toThrow(/expired/i);
+  });
+
+  it('rejects a missing exp', () => {
+    const claims = validClaims({ exp: undefined });
+    expect(() => validateIdTokenClaims(claims, opts())).toThrow(/exp/i);
+  });
+
+  it('rejects a token that is not yet valid (nbf in the future beyond skew)', () => {
+    const claims = validClaims({ nbf: NOW + 1000 });
+    expect(() =>
+      validateIdTokenClaims(claims, opts({ clockSkewSeconds: 300 }))
+    ).toThrow(/not yet valid/i);
+  });
+
+  it('rejects a nonce mismatch', () => {
+    const claims = validClaims({ nonce: 'attacker-nonce' });
+    expect(() => validateIdTokenClaims(claims, opts({ nonce: 'nonce-123' }))).toThrow(
+      /nonce/i
+    );
+  });
+
+  it('rejects when a nonce was expected but the token has none', () => {
+    const claims = validClaims({ nonce: undefined });
+    expect(() => validateIdTokenClaims(claims, opts({ nonce: 'nonce-123' }))).toThrow(
+      /nonce/i
+    );
+  });
+});

--- a/backend/src/services/__tests__/ssoStateStore.test.ts
+++ b/backend/src/services/__tests__/ssoStateStore.test.ts
@@ -1,0 +1,105 @@
+// backend/src/services/__tests__/ssoStateStore.test.ts
+// Unit tests for the session-backed SSO state store: put/consume, CSRF mismatch
+// rejection, single-use semantics, and expiry. Uses a plain object as the
+// session stub (no express-session runtime needed).
+import {
+  putState,
+  consumeState,
+  SSOStateError,
+  SSOStateSession,
+  SSO_STATE_TTL_MS,
+} from '../ssoStateStore';
+import { PendingSSOState } from '../../types/sso';
+
+function makePending(overrides: Partial<PendingSSOState> = {}): PendingSSOState {
+  return {
+    state: 'a'.repeat(64),
+    nonce: 'b'.repeat(64),
+    redirectUri: 'https://app.example.com/api/auth/sso/callback',
+    timestamp: 1_000_000,
+    ...overrides,
+  };
+}
+
+describe('ssoStateStore', () => {
+  it('putState stashes the pending state on the session', () => {
+    const session: SSOStateSession = {};
+    const pending = makePending();
+    putState(session, pending);
+    expect(session.ssoState).toEqual(pending);
+  });
+
+  it('consumeState returns the pending state on a matching token', () => {
+    const pending = makePending();
+    const session: SSOStateSession = { ssoState: pending };
+    const result = consumeState(session, pending.state, pending.timestamp + 1000);
+    expect(result).toEqual(pending);
+  });
+
+  it('is single-use: a matched state is cleared and cannot be replayed', () => {
+    const pending = makePending();
+    const session: SSOStateSession = { ssoState: pending };
+
+    consumeState(session, pending.state, pending.timestamp + 1000);
+    expect(session.ssoState).toBeUndefined();
+
+    expect(() => consumeState(session, pending.state, pending.timestamp + 1000)).toThrow(
+      SSOStateError
+    );
+  });
+
+  it('rejects a mismatched state (CSRF protection) and still burns the stored value', () => {
+    const pending = makePending();
+    const session: SSOStateSession = { ssoState: pending };
+
+    try {
+      consumeState(session, 'c'.repeat(64), pending.timestamp + 1000);
+      fail('expected consumeState to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SSOStateError);
+      expect((err as SSOStateError).code).toBe('MISMATCH');
+    }
+    // Single-use even on failure: a captured state cannot be retried.
+    expect(session.ssoState).toBeUndefined();
+  });
+
+  it('rejects when no state is pending on the session', () => {
+    const session: SSOStateSession = {};
+    try {
+      consumeState(session, 'a'.repeat(64));
+      fail('expected consumeState to throw');
+    } catch (err) {
+      expect((err as SSOStateError).code).toBe('MISSING');
+    }
+  });
+
+  it('rejects a non-string supplied state', () => {
+    const pending = makePending();
+    const session: SSOStateSession = { ssoState: pending };
+    try {
+      consumeState(session, undefined, pending.timestamp + 1000);
+      fail('expected consumeState to throw');
+    } catch (err) {
+      expect((err as SSOStateError).code).toBe('MISMATCH');
+    }
+  });
+
+  it('rejects an expired state token', () => {
+    const pending = makePending();
+    const session: SSOStateSession = { ssoState: pending };
+    const now = pending.timestamp + SSO_STATE_TTL_MS + 1;
+    try {
+      consumeState(session, pending.state, now);
+      fail('expected consumeState to throw');
+    } catch (err) {
+      expect((err as SSOStateError).code).toBe('EXPIRED');
+    }
+  });
+
+  it('accepts a token right at the TTL boundary', () => {
+    const pending = makePending();
+    const session: SSOStateSession = { ssoState: pending };
+    const now = pending.timestamp + SSO_STATE_TTL_MS;
+    expect(() => consumeState(session, pending.state, now)).not.toThrow();
+  });
+});

--- a/backend/src/services/msalService.ts
+++ b/backend/src/services/msalService.ts
@@ -1,7 +1,88 @@
 // backend/src/services/msalService.ts
 import * as msal from '@azure/msal-node';
 import { ssoConfigService } from './ssoConfigService';
-import { SSOProvider } from '../types/sso';
+import { SSOProvider, IdTokenClaims } from '../types/sso';
+
+// Multi-tenant authority segments. When the configured tenant is one of these,
+// the id_token `iss` carries the caller's real tenant GUID rather than the
+// placeholder, so the issuer is matched by shape instead of exact string.
+const MULTI_TENANT_SEGMENTS = new Set(['common', 'organizations', 'consumers']);
+
+// Entra ID v2.0 issuer for a concrete tenant GUID.
+const ENTRA_V2_ISSUER = (tenantId: string): string =>
+  `https://login.microsoftonline.com/${tenantId}/v2.0`;
+
+// Matches a v2.0 issuer for any tenant GUID (used for multi-tenant configs).
+const ENTRA_V2_ISSUER_PATTERN =
+  /^https:\/\/login\.microsoftonline\.com\/[0-9a-fA-F-]{36}\/v2\.0$/;
+
+export interface ClaimsValidationOptions {
+  // Configured tenant id (GUID, or a multi-tenant segment such as "common").
+  tenantId: string;
+  // Expected audience — the application's client id.
+  audience: string;
+  // Nonce issued at /signin; when provided, the id_token nonce must match it.
+  nonce?: string;
+  // Overridable clock (seconds since epoch) for testing.
+  nowSeconds?: number;
+  // Allowed clock skew when checking exp/nbf.
+  clockSkewSeconds?: number;
+}
+
+function issuerMatches(actual: string, tenantId: string): boolean {
+  if (MULTI_TENANT_SEGMENTS.has(tenantId.toLowerCase())) {
+    return ENTRA_V2_ISSUER_PATTERN.test(actual);
+  }
+  return actual === ENTRA_V2_ISSUER(tenantId);
+}
+
+/**
+ * Assert that an id_token's security-critical claims are trustworthy before a
+ * session is minted from them. MSAL already parses (and, during the
+ * authorization-code exchange, validates) these claims; this is a defensive,
+ * dependency-free second check of issuer / audience / expiry / not-before /
+ * nonce so a misconfiguration or future flow change cannot silently create a
+ * session from an untrusted token.
+ *
+ * Pure and side-effect free so it can be unit-tested directly. Throws on any
+ * failure; returns void on success.
+ */
+export function validateIdTokenClaims(
+  claims: IdTokenClaims,
+  options: ClaimsValidationOptions
+): void {
+  const skew = options.clockSkewSeconds ?? 300;
+  const now = options.nowSeconds ?? Math.floor(Date.now() / 1000);
+
+  // Issuer must match the configured Entra tenant authority.
+  if (typeof claims.iss !== 'string' || !issuerMatches(claims.iss, options.tenantId)) {
+    throw new Error('ID token issuer mismatch');
+  }
+
+  // Audience must be (or include) our client id.
+  const aud = claims.aud;
+  const audienceOk = Array.isArray(aud)
+    ? aud.includes(options.audience)
+    : aud === options.audience;
+  if (!audienceOk) {
+    throw new Error('ID token audience mismatch');
+  }
+
+  // Expiry must be present and in the future (allowing for clock skew).
+  if (typeof claims.exp !== 'number' || now > claims.exp + skew) {
+    throw new Error('ID token expired or missing exp');
+  }
+
+  // Not-before, when present, must not be in the future (allowing for skew).
+  if (typeof claims.nbf === 'number' && now + skew < claims.nbf) {
+    throw new Error('ID token not yet valid (nbf)');
+  }
+
+  // Nonce, when we issued one, must match to defend against token replay.
+  if (options.nonce !== undefined && claims.nonce !== options.nonce) {
+    throw new Error('ID token nonce mismatch');
+  }
+}
 
 class MSALService {
   private msalClient: msal.ConfidentialClientApplication | null = null;
@@ -77,7 +158,7 @@ class MSALService {
   /**
    * Get authorization URL for user sign-in
    */
-  async getAuthCodeUrl(state: string, redirectUri: string): Promise<string> {
+  async getAuthCodeUrl(state: string, redirectUri: string, nonce?: string): Promise<string> {
     if (!this.isReady()) {
       await this.initialize();
     }
@@ -92,6 +173,12 @@ class MSALService {
       state: state,
       prompt: 'select_account', // Force account selection
     };
+
+    // Bind a nonce into the request so it is embedded in the returned id_token;
+    // validated at callback to defend against token replay.
+    if (nonce) {
+      authCodeUrlParameters.nonce = nonce;
+    }
 
     return await this.msalClient.getAuthCodeUrl(authCodeUrlParameters);
   }
@@ -132,25 +219,43 @@ class MSALService {
   }
 
   /**
-   * Validate and decode ID token
+   * Return the id_token claims from a token response, but only after asserting
+   * they are trustworthy (issuer / audience / expiry / nonce).
+   *
+   * Trust model: `acquireTokenByCode` is a server-to-server call to the Entra
+   * token endpoint over TLS, and MSAL itself parses and validates the id_token
+   * during that exchange, exposing the result as `AuthenticationResult
+   * .idTokenClaims`. We therefore consume MSAL's already-validated claims rather
+   * than hand-decoding the raw JWT (the previous behaviour) — this avoids
+   * rolling our own JWKS-based signature verification while still refusing to
+   * mint a session from a token whose issuer/audience/expiry/nonce do not match
+   * the configured tenant/client and the nonce we issued at /signin.
+   *
+   * @param expectedNonce the nonce issued at /signin (bound into the id_token).
    */
-  decodeIdToken(idToken: string): any {
-    try {
-      const base64Url = idToken.split('.')[1];
-      const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-      const jsonPayload = decodeURIComponent(
-        Buffer.from(base64, 'base64')
-          .toString()
-          .split('')
-          .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
-          .join('')
-      );
-
-      return JSON.parse(jsonPayload);
-    } catch (error) {
-      console.error('Failed to decode ID token:', error);
-      throw new Error('Invalid ID token');
+  async getValidatedIdTokenClaims(
+    tokenResponse: msal.AuthenticationResult,
+    expectedNonce?: string
+  ): Promise<IdTokenClaims> {
+    const config = await ssoConfigService.getFullConfig();
+    if (!config?.clientId || !config?.tenantId) {
+      throw new Error('SSO not configured');
     }
+
+    const claims = tokenResponse.idTokenClaims as IdTokenClaims | undefined;
+    if (!claims) {
+      // MSAL always populates idTokenClaims on a successful code exchange; a
+      // missing value means the response is not one we should trust.
+      throw new Error('ID token claims missing from token response');
+    }
+
+    validateIdTokenClaims(claims, {
+      tenantId: config.tenantId,
+      audience: config.clientId,
+      nonce: expectedNonce,
+    });
+
+    return claims;
   }
 }
 

--- a/backend/src/services/ssoStateStore.ts
+++ b/backend/src/services/ssoStateStore.ts
@@ -1,0 +1,87 @@
+// backend/src/services/ssoStateStore.ts
+// Session-backed store for the OAuth2 authorization-code-flow CSRF `state`
+// (and its bound `nonce`). Replaces the former process-global in-memory Map,
+// which broke across multiple backend instances and lost in-flight logins on
+// restart. State now lives on the express session, so it survives restarts,
+// works behind a load balancer, and is naturally scoped to one browser session.
+//
+// Semantics preserved from the previous implementation:
+//   - CSRF protection: a callback whose `state` is missing or does not match the
+//     value issued at /signin is rejected.
+//   - Single-use: the pending state is cleared on the first consume attempt
+//     (success OR failure), so a captured `state` cannot be replayed.
+import crypto from 'crypto';
+import { PendingSSOState } from '../types/sso';
+
+// Minimal session shape we depend on. Accepting an interface (rather than the
+// full express-session Session) keeps this module unit-testable with a plain
+// object stub.
+export interface SSOStateSession {
+  ssoState?: PendingSSOState;
+}
+
+// In-flight logins older than this are treated as expired.
+export const SSO_STATE_TTL_MS = 5 * 60 * 1000;
+
+export type SSOStateErrorCode = 'MISSING' | 'MISMATCH' | 'EXPIRED';
+
+/** Thrown by consumeState when validation fails; carries a machine code. */
+export class SSOStateError extends Error {
+  constructor(public readonly code: SSOStateErrorCode, message: string) {
+    super(message);
+    this.name = 'SSOStateError';
+  }
+}
+
+/**
+ * Persist the pending SSO state on the session at /signin. Writing to the
+ * session marks it dirty, so express-session issues the cookie even with
+ * saveUninitialized:false.
+ */
+export function putState(session: SSOStateSession, pending: PendingSSOState): void {
+  session.ssoState = pending;
+}
+
+/** Constant-time comparison that never throws on length/shape mismatch. */
+function safeEquals(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, 'utf8');
+  const bufB = Buffer.from(b, 'utf8');
+  if (bufA.length !== bufB.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * Validate and consume the pending SSO state at /callback.
+ *
+ * Single-use is enforced by clearing session.ssoState up front, before any
+ * validation branch, so every code path (match, mismatch, expiry) burns the
+ * stored value exactly once.
+ *
+ * @throws SSOStateError when no state is pending (MISSING), the supplied state
+ *   does not match (MISMATCH), or the pending state has expired (EXPIRED).
+ */
+export function consumeState(
+  session: SSOStateSession,
+  suppliedState: unknown,
+  now: number = Date.now()
+): PendingSSOState {
+  const pending = session.ssoState;
+  // Burn the stored value first — single-use regardless of outcome.
+  delete session.ssoState;
+
+  if (!pending) {
+    throw new SSOStateError('MISSING', 'No pending SSO state on session');
+  }
+
+  if (typeof suppliedState !== 'string' || !safeEquals(pending.state, suppliedState)) {
+    throw new SSOStateError('MISMATCH', 'SSO state token mismatch');
+  }
+
+  if (now - pending.timestamp > SSO_STATE_TTL_MS) {
+    throw new SSOStateError('EXPIRED', 'SSO state token expired');
+  }
+
+  return pending;
+}

--- a/backend/src/types/sso.ts
+++ b/backend/src/types/sso.ts
@@ -30,3 +30,49 @@ export interface SSOConfigResponse {
   editorGroups?: string[];
   // Note: clientSecret is NEVER returned
 }
+
+/**
+ * Pending OAuth2 authorization-code-flow state, created at /signin and consumed
+ * once at /callback. Stashed on the express session (see augmentation below) so
+ * it survives backend restarts and multi-instance deployments, and is scoped to
+ * the browser session rather than a process-global map.
+ */
+export interface PendingSSOState {
+  // Opaque CSRF token echoed back by the IdP in the callback `state` param.
+  state: string;
+  // Opaque nonce bound into the id_token to defend against token replay.
+  nonce: string;
+  // Redirect URI used for the auth request; must match on token exchange.
+  redirectUri: string;
+  // Creation time (ms epoch); used to expire abandoned in-flight logins.
+  timestamp: number;
+}
+
+/**
+ * Subset of Entra ID id_token claims this app relies on. MSAL populates and
+ * validates these during the authorization-code exchange; we additionally
+ * assert issuer/audience/expiry/nonce before trusting them (see msalService).
+ */
+export interface IdTokenClaims {
+  // Standard OIDC claims used for validation.
+  iss?: string;
+  aud?: string | string[];
+  exp?: number;
+  nbf?: number;
+  nonce?: string;
+  // Identity claims used for JIT provisioning.
+  oid?: string;
+  preferred_username?: string;
+  email?: string;
+  upn?: string;
+  roles?: string[];
+  [claim: string]: unknown;
+}
+
+// Bind the pending SSO state onto the express session type so route handlers can
+// read/write req.session.ssoState with full type-safety.
+declare module 'express-session' {
+  interface SessionData {
+    ssoState?: PendingSSOState;
+  }
+}


### PR DESCRIPTION
## Summary

Two approved SSO hardening items.

**1. Verify the id token instead of blind-decoding it.** The callback base64-decoded the JWT payload with no validation. It now uses MSAL's already-validated `idTokenClaims` from `acquireTokenByCode` (no hand-rolled crypto), and adds a dependency-free `validateIdTokenClaims` assertion before any session is created: issuer matches the configured Entra authority (with a GUID fallback for `common`/`organizations`/`consumers`), audience matches the client id, `exp`/`nbf` current (300s skew), and **nonce** matches the value now issued at `/signin` and embedded in the token — adding replay defense. Tokens missing `oid`/username are rejected.

**2. Move OAuth CSRF state off the in-memory Map.** Removed the process-global Map + `setInterval` cleanup. New `ssoStateStore.ts` stashes `{state, nonce, redirectUri, timestamp}` on the file-backed `req.session` (survives restarts, multi-instance, scoped per browser). Single-use (`consumeState` deletes up front so success/mismatch/expiry all burn the value once), CSRF-rejecting on missing/mismatched state via constant-time `timingSafeEqual`, 5-minute TTL. SameSite=Lax confirmed to allow the top-level callback navigation.

## Testing

23 new tests (claims acceptance/rejection across issuer/audience/expiry/nonce; state put/consume/replay/mismatch/expiry). Backend 273 tests green; lint 0 errors; build clean. No supertest infra, so the security-critical logic is extracted into the two covered helpers rather than an HTTP round-trip test (noted).