### PR TITLE
fix(auth): force default-admin password rotation; require current password on self-reset

### DIFF
--- a/backend/src/middleware/__tests__/requirePasswordCurrent.test.ts
+++ b/backend/src/middleware/__tests__/requirePasswordCurrent.test.ts
@@ -1,0 +1,75 @@
+// backend/src/middleware/__tests__/requirePasswordCurrent.test.ts
+// Unit tests for the requirePasswordCurrent guard that blocks mutating actions
+// while an account still owes a forced password change.
+import { Request, Response } from 'express';
+import { requirePasswordCurrent } from '../auth';
+import { UserRole, AuthenticatedRequest } from '../../types/auth';
+
+function makeRes(): Response & { statusCode?: number; body?: unknown } {
+  const res = {} as Response & { statusCode?: number; body?: unknown };
+  res.status = jest.fn().mockImplementation((code: number) => {
+    res.statusCode = code;
+    return res;
+  });
+  res.json = jest.fn().mockImplementation((payload: unknown) => {
+    res.body = payload;
+    return res;
+  });
+  return res;
+}
+
+function makeReq(user?: AuthenticatedRequest['user']): Request {
+  return { user } as unknown as Request;
+}
+
+describe('requirePasswordCurrent', () => {
+  const baseUser = {
+    userId: 'u1',
+    username: 'admin',
+    role: UserRole.ADMIN,
+    allowedKeyIds: [],
+    allowedZones: [],
+  };
+
+  it('rejects with 401 when the request is not authenticated', () => {
+    const res = makeRes();
+    const next = jest.fn();
+
+    requirePasswordCurrent(makeReq(undefined), res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+    expect((res.body as { code: string }).code).toBe('NOT_AUTHENTICATED');
+  });
+
+  it('blocks with 403 PASSWORD_CHANGE_REQUIRED when the flag is set', () => {
+    const res = makeRes();
+    const next = jest.fn();
+
+    requirePasswordCurrent(makeReq({ ...baseUser, mustChangePassword: true }), res, next);
+
+    expect(res.statusCode).toBe(403);
+    expect(next).not.toHaveBeenCalled();
+    expect((res.body as { code: string }).code).toBe('PASSWORD_CHANGE_REQUIRED');
+  });
+
+  it('allows the request when the flag is false', () => {
+    const res = makeRes();
+    const next = jest.fn();
+
+    requirePasswordCurrent(makeReq({ ...baseUser, mustChangePassword: false }), res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('allows the request when the flag is absent (e.g. SSO users)', () => {
+    const res = makeRes();
+    const next = jest.fn();
+
+    requirePasswordCurrent(makeReq({ ...baseUser }), res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -42,13 +42,16 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
       return;
     }
 
-    // Identity comes from the session; privileges come from the database.
+    // Identity comes from the session; privileges (and the forced
+    // password-change flag) come from the database so a cleared flag takes
+    // effect on the very next request.
     authReq.user = {
       userId: req.session.userId,
       username: req.session.username || dbUser.username,
       role: dbUser.role,
       allowedKeyIds: dbUser.allowedKeyIds,
       allowedZones: dbUser.allowedZones || [],
+      mustChangePassword: dbUser.mustChangePassword ?? false,
     };
 
     next();
@@ -88,6 +91,41 @@ export function requireRole(...roles: UserRole[]) {
 
     next();
   };
+}
+
+/**
+ * Middleware that blocks mutating actions while the account still owes a
+ * forced password change (e.g. the seeded default admin, or a user whose
+ * password was set by an administrator).
+ *
+ * Must run AFTER requireAuth, which loads the authoritative mustChangePassword
+ * flag from the user store onto req.user. Login, logout, session, and
+ * change-password are intentionally NOT wrapped with this guard so the user
+ * can still authenticate and clear the flag. SSO users have no local password
+ * and never carry the flag, so their requests pass through untouched.
+ */
+export function requirePasswordCurrent(req: Request, res: Response, next: NextFunction): void {
+  const authReq = req as AuthenticatedRequest;
+
+  if (!authReq.user) {
+    res.status(401).json({
+      success: false,
+      error: 'Authentication required',
+      code: 'NOT_AUTHENTICATED'
+    });
+    return;
+  }
+
+  if (authReq.user.mustChangePassword) {
+    res.status(403).json({
+      success: false,
+      error: 'You must change your password before performing this action',
+      code: 'PASSWORD_CHANGE_REQUIRED'
+    });
+    return;
+  }
+
+  next();
 }
 
 /**

--- a/backend/src/routes/__tests__/authRoutes.selfReset.test.ts
+++ b/backend/src/routes/__tests__/authRoutes.selfReset.test.ts
@@ -1,0 +1,15 @@
+// backend/src/routes/__tests__/authRoutes.selfReset.test.ts
+// Unit test for the self-vs-other decision that gates the current-password
+// requirement on PATCH /users/:userId/password. An admin resetting their OWN
+// password must supply the current password; resetting another user's must not.
+import { selfPasswordResetRequiresCurrent } from '../authRoutes';
+
+describe('selfPasswordResetRequiresCurrent', () => {
+  it('requires the current password when an admin resets their own password', () => {
+    expect(selfPasswordResetRequiresCurrent('admin-id', 'admin-id')).toBe(true);
+  });
+
+  it('does not require the current password when resetting another user', () => {
+    expect(selfPasswordResetRequiresCurrent('target-user-id', 'admin-id')).toBe(false);
+  });
+});

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -4,13 +4,23 @@ import { rateLimit } from 'express-rate-limit';
 import { isRateLimitEnabled } from '../config/securityToggles';
 import { userService } from '../services/userService';
 import { auditService, AuditEventType } from '../services/auditService';
-import { requireAuth, requireRole } from '../middleware/auth';
+import { requireAuth, requireRole, requirePasswordCurrent } from '../middleware/auth';
 import { LoginCredentials, UserCreateData, UserRole, AuthenticatedRequest } from '../types/auth';
 import { validateLogin, validateUserCreate, validateChangePassword } from '../middleware/validation';
 import { getClientIp } from '../helpers/ipHelpers';
 import { regenerateSession } from '../helpers/session';
 
 const router = Router();
+
+/**
+ * An admin resetting a password via PATCH /users/:userId/password may reset any
+ * OTHER user's password without knowing it, but resetting their OWN password
+ * through this endpoint must require the current password (mirroring the
+ * self-service /change-password endpoint). Extracted for unit testing.
+ */
+export function selfPasswordResetRequiresCurrent(targetUserId: string, actingUserId: string): boolean {
+  return targetUserId === actingUserId;
+}
 
 // Rate limiting for login attempts
 const loginLimiter = rateLimit({
@@ -77,6 +87,7 @@ router.post('/login', loginLimiter, validateLogin, async (req: Request, res: Res
     req.session.role = user.role;
     req.session.allowedKeyIds = user.allowedKeyIds;
     req.session.allowedZones = user.allowedZones || [];
+    req.session.mustChangePassword = user.mustChangePassword ?? false;
 
     // Log successful login
     await auditService.logAuth(
@@ -98,6 +109,7 @@ router.post('/login', loginLimiter, validateLogin, async (req: Request, res: Res
         email: user.email,
         allowedKeyIds: user.allowedKeyIds,
         allowedZones: user.allowedZones || [],
+        mustChangePassword: user.mustChangePassword ?? false,
       }
     });
   } catch (error) {
@@ -164,6 +176,7 @@ router.get('/session', (req: Request, res: Response) => {
       role: req.session.role,
       allowedKeyIds: req.session.allowedKeyIds,
       allowedZones: req.session.allowedZones || [],
+      mustChangePassword: req.session.mustChangePassword ?? false,
     }
   });
 });
@@ -212,8 +225,11 @@ router.post('/change-password', requireAuth, validateChangePassword, async (req:
       });
     }
 
-    // Update password
+    // Update password. The user chose this password themselves, so clear any
+    // forced-change flag (updatePassword defaults mustChangePassword to false)
+    // and mirror that into the session so /session reflects it immediately.
     await userService.updatePassword(user.id, newPassword);
+    req.session.mustChangePassword = false;
 
     // Log password change
     await auditService.log(AuditEventType.PASSWORD_CHANGE, {
@@ -242,7 +258,7 @@ router.post('/change-password', requireAuth, validateChangePassword, async (req:
  * POST /api/auth/users
  * Create a new user (admin only)
  */
-router.post('/users', requireAuth, requireRole(UserRole.ADMIN), validateUserCreate, async (req: Request, res: Response) => {
+router.post('/users', requireAuth, requirePasswordCurrent, requireRole(UserRole.ADMIN), validateUserCreate, async (req: Request, res: Response) => {
   try {
     const userData: UserCreateData = req.body;
 
@@ -326,7 +342,7 @@ router.get('/users', requireAuth, requireRole(UserRole.ADMIN), async (req: Reque
  * DELETE /api/auth/users/:userId
  * Delete a user (admin only)
  */
-router.delete('/users/:userId', requireAuth, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
+router.delete('/users/:userId', requireAuth, requirePasswordCurrent, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
   try {
     const { userId } = req.params;
     const authReq = req as AuthenticatedRequest;
@@ -385,7 +401,7 @@ router.delete('/users/:userId', requireAuth, requireRole(UserRole.ADMIN), async 
  * PATCH /api/auth/users/:userId/role
  * Update user role (admin only)
  */
-router.patch('/users/:userId/role', requireAuth, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
+router.patch('/users/:userId/role', requireAuth, requirePasswordCurrent, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
   try {
     const { userId } = req.params;
     const { role } = req.body;
@@ -462,7 +478,7 @@ router.patch('/users/:userId/role', requireAuth, requireRole(UserRole.ADMIN), as
  * PATCH /api/auth/users/:userId/keys
  * Update user's allowed key IDs (admin only)
  */
-router.patch('/users/:userId/keys', requireAuth, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
+router.patch('/users/:userId/keys', requireAuth, requirePasswordCurrent, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
   try {
     const { userId } = req.params;
     const { keyIds } = req.body;
@@ -529,7 +545,7 @@ router.patch('/users/:userId/keys', requireAuth, requireRole(UserRole.ADMIN), as
  * PATCH /api/auth/users/:userId/zones
  * Update user's allowed zone names (admin only)
  */
-router.patch('/users/:userId/zones', requireAuth, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
+router.patch('/users/:userId/zones', requireAuth, requirePasswordCurrent, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
   try {
     const { userId } = req.params;
     const { zones } = req.body;
@@ -605,10 +621,20 @@ router.patch('/users/:userId/zones', requireAuth, requireRole(UserRole.ADMIN), a
  * PATCH /api/auth/users/:userId/password
  * Reset user password (admin only)
  */
-router.patch('/users/:userId/password', requireAuth, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
+router.patch('/users/:userId/password', requireAuth, requirePasswordCurrent, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
   try {
     const { userId } = req.params;
-    const { newPassword } = req.body;
+    const { newPassword, currentPassword } = req.body;
+    const authReq = req as AuthenticatedRequest;
+    const actingUser = authReq.user;
+
+    if (!actingUser) {
+      return res.status(401).json({
+        success: false,
+        error: 'Authentication required',
+        code: 'NOT_AUTHENTICATED'
+      });
+    }
 
     if (!newPassword || newPassword.length < 8) {
       return res.status(400).json({
@@ -628,7 +654,36 @@ router.patch('/users/:userId/password', requireAuth, requireRole(UserRole.ADMIN)
       });
     }
 
-    await userService.updatePassword(userId, newPassword);
+    // Resetting your OWN password through this admin endpoint requires the
+    // current password, just like /change-password. Resetting ANOTHER user's
+    // password does not (that is the intended admin reset flow).
+    const isSelfReset = selfPasswordResetRequiresCurrent(userId, actingUser.userId);
+    if (isSelfReset) {
+      if (!currentPassword) {
+        return res.status(400).json({
+          success: false,
+          error: 'Current password is required to reset your own password',
+          code: 'MISSING_CURRENT_PASSWORD'
+        });
+      }
+
+      const authenticated = await userService.authenticate(user.username, currentPassword);
+      if (!authenticated) {
+        return res.status(401).json({
+          success: false,
+          error: 'Current password is incorrect',
+          code: 'INVALID_PASSWORD'
+        });
+      }
+    }
+
+    // Self-reset: the user chose this password, so clear the forced-change flag.
+    // Admin resetting another user: force that user to rotate the admin-set
+    // password on first use.
+    await userService.updatePassword(userId, newPassword, !isSelfReset);
+    if (isSelfReset) {
+      req.session.mustChangePassword = false;
+    }
 
     // Log password reset
     await auditService.log(AuditEventType.PASSWORD_RESET, {

--- a/backend/src/routes/backupRoutes.ts
+++ b/backend/src/routes/backupRoutes.ts
@@ -1,6 +1,6 @@
 // backend/src/routes/backupRoutes.ts
 import { Router, Request, Response } from 'express';
-import { requireAuth, requireWriteAccess } from '../middleware/auth';
+import { requireAuth, requireWriteAccess, requirePasswordCurrent } from '../middleware/auth';
 import { AuthenticatedRequest } from '../types/auth';
 import { backupService } from '../services/backupService';
 import { auditService, AuditEventType } from '../services/auditService';
@@ -104,7 +104,7 @@ router.get('/zone/:zone/:backupId', requireAuth, async (req: Request, res: Respo
  */
 // Creating a backup writes a server-side file, so it is a write operation:
 // viewers (read-only) must not be able to reach it.
-router.post('/zone/:zone', requireAuth, requireWriteAccess, async (req: Request, res: Response) => {
+router.post('/zone/:zone', requireAuth, requireWriteAccess, requirePasswordCurrent, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthenticatedRequest;
     const user = authReq.user!;

--- a/backend/src/routes/ssoConfigRoutes.ts
+++ b/backend/src/routes/ssoConfigRoutes.ts
@@ -1,6 +1,6 @@
 // backend/src/routes/ssoConfigRoutes.ts
 import { Router, Request, Response } from 'express';
-import { requireAuth, requireRole } from '../middleware/auth';
+import { requireAuth, requireRole, requirePasswordCurrent } from '../middleware/auth';
 import { UserRole } from '../types/auth';
 import { ssoConfigService } from '../services/ssoConfigService';
 import { SSOConfig, SSOProvider } from '../types/sso';
@@ -46,7 +46,7 @@ router.get('/', requireAuth, requireRole(UserRole.ADMIN), async (req: Request, r
  * PUT /api/sso-config
  * Update SSO configuration (admin only)
  */
-router.put('/', requireAuth, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
+router.put('/', requireAuth, requirePasswordCurrent, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
   try {
     const updates: Partial<SSOConfig> = req.body;
 
@@ -108,7 +108,7 @@ router.put('/', requireAuth, requireRole(UserRole.ADMIN), async (req: Request, r
  * POST /api/sso-config/test
  * Test SSO configuration (admin only)
  */
-router.post('/test', requireAuth, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
+router.post('/test', requireAuth, requirePasswordCurrent, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
   try {
     const config = await ssoConfigService.getFullConfig();
 

--- a/backend/src/routes/tsigKeyRoutes.ts
+++ b/backend/src/routes/tsigKeyRoutes.ts
@@ -1,6 +1,6 @@
 // backend/src/routes/tsigKeyRoutes.ts
 import { Router, Request, Response } from 'express';
-import { requireAuth, requireRole, requireWriteAccess } from '../middleware/auth';
+import { requireAuth, requireRole, requireWriteAccess, requirePasswordCurrent } from '../middleware/auth';
 import { AuthenticatedRequest, UserRole } from '../types/auth';
 import { tsigKeyService, TSIGKeyCreate } from '../services/tsigKeyService';
 import { keyManagementLimiter } from '../middleware/rateLimiter';
@@ -43,7 +43,7 @@ router.get('/', requireAuth, async (req: Request, res: Response) => {
  * POST /api/tsig-keys
  * Create a new TSIG key (admin or editor only)
  */
-router.post('/', requireAuth, requireWriteAccess, validateTSIGKeyCreate, async (req: Request, res: Response) => {
+router.post('/', requireAuth, requirePasswordCurrent, requireWriteAccess, validateTSIGKeyCreate, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthenticatedRequest;
     const user = authReq.user!;
@@ -134,7 +134,7 @@ router.get('/:keyId', requireAuth, async (req: Request, res: Response) => {
  * PUT /api/tsig-keys/:keyId
  * Update a TSIG key (admin or editor only)
  */
-router.put('/:keyId', requireAuth, requireWriteAccess, validateTSIGKeyUpdate, async (req: Request, res: Response) => {
+router.put('/:keyId', requireAuth, requirePasswordCurrent, requireWriteAccess, validateTSIGKeyUpdate, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthenticatedRequest;
     const user = authReq.user!;
@@ -189,7 +189,7 @@ router.put('/:keyId', requireAuth, requireWriteAccess, validateTSIGKeyUpdate, as
  * DELETE /api/tsig-keys/:keyId
  * Delete a TSIG key (admin only)
  */
-router.delete('/:keyId', requireAuth, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
+router.delete('/:keyId', requireAuth, requirePasswordCurrent, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthenticatedRequest;
     const user = authReq.user!;

--- a/backend/src/routes/webhookConfigRoutes.ts
+++ b/backend/src/routes/webhookConfigRoutes.ts
@@ -1,6 +1,6 @@
 // backend/src/routes/webhookConfigRoutes.ts
 import { Router, Request, Response } from 'express';
-import { requireAuth, requireRole } from '../middleware/auth';
+import { requireAuth, requireRole, requirePasswordCurrent } from '../middleware/auth';
 import { AuthenticatedRequest, UserRole } from '../types/auth';
 import { webhookConfigService } from '../services/webhookConfigService';
 import { auditService, AuditEventType } from '../services/auditService';
@@ -50,7 +50,7 @@ router.get('/', requireAuth, async (req: Request, res: Response) => {
  * PUT /api/webhook-config
  * Update webhook configuration for the authenticated user
  */
-router.put('/', requireAuth, async (req: Request, res: Response) => {
+router.put('/', requireAuth, requirePasswordCurrent, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthenticatedRequest;
     const user = authReq.user!;
@@ -119,7 +119,7 @@ router.put('/', requireAuth, async (req: Request, res: Response) => {
  * DELETE /api/webhook-config
  * Delete webhook configuration for the authenticated user
  */
-router.delete('/', requireAuth, async (req: Request, res: Response) => {
+router.delete('/', requireAuth, requirePasswordCurrent, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthenticatedRequest;
     const user = authReq.user!;

--- a/backend/src/routes/zoneRoutes.ts
+++ b/backend/src/routes/zoneRoutes.ts
@@ -2,7 +2,7 @@
 import { Router, Request, Response } from 'express';
 import { ZoneConfig } from '../types/dns';
 import { dnsService } from '../services';
-import { requireAuth, requireWriteAccess } from '../middleware/auth';
+import { requireAuth, requireWriteAccess, requirePasswordCurrent } from '../middleware/auth';
 import { AuthenticatedRequest } from '../types/auth';
 import { tsigKeyService } from '../services/tsigKeyService';
 import { userService } from '../services/userService';
@@ -132,6 +132,7 @@ router.post(
   '/:zone/records',
   dnsModifyLimiter,
   requireAuth,
+  requirePasswordCurrent,
   requireWriteAccess,
   validateAddRecord,
   async (req: Request, res: Response) => {
@@ -240,6 +241,7 @@ router.delete(
   '/:zone/records',
   dnsModifyLimiter,
   requireAuth,
+  requirePasswordCurrent,
   requireWriteAccess,
   validateDeleteRecord,
   async (req: Request, res: Response) => {
@@ -358,6 +360,7 @@ router.patch(
   '/:zone/records',
   dnsModifyLimiter,
   requireAuth,
+  requirePasswordCurrent,
   requireWriteAccess,
   validateUpdateRecord,
   async (req: Request, res: Response) => {
@@ -497,6 +500,7 @@ router.post(
   '/:zone/records/batch',
   dnsModifyLimiter,
   requireAuth,
+  requirePasswordCurrent,
   requireWriteAccess,
   validateBatch,
   async (req: Request, res: Response) => {

--- a/backend/src/services/__tests__/userService.mustChangePassword.test.ts
+++ b/backend/src/services/__tests__/userService.mustChangePassword.test.ts
@@ -1,0 +1,76 @@
+// backend/src/services/__tests__/userService.mustChangePassword.test.ts
+// Verifies the forced-password-change lifecycle on userService:
+// - the seeded default admin is created with mustChangePassword = true
+// - admin-created users are forced to change their initial password
+// - updatePassword clears the flag by default (self-service change)
+// - updatePassword can force a change (admin resetting another user)
+// fs.promises is mocked so the service never touches disk; the rest of fs
+// (e.g. existsSync, used by bcrypt's native-binding loader) stays real, and
+// bcrypt itself runs for real.
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      mkdir: jest.fn().mockResolvedValue(undefined),
+      // ENOENT drives initialize() down the "create default admin" path.
+      readFile: jest.fn().mockRejectedValue({ code: 'ENOENT' }),
+      writeFile: jest.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+import { userService } from '../userService';
+import { UserRole } from '../../types/auth';
+
+describe('userService mustChangePassword lifecycle', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(jest.fn());
+    jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('seeds the default admin with mustChangePassword = true', async () => {
+    await userService.initialize();
+
+    const admin = await userService.getUserByUsername('admin');
+    expect(admin).not.toBeNull();
+    expect(admin!.mustChangePassword).toBe(true);
+  });
+
+  it('clears the flag when the password is changed by the user (default)', async () => {
+    await userService.initialize();
+    const admin = await userService.getUserByUsername('admin');
+
+    await userService.updatePassword(admin!.id, 'a-new-strong-password');
+
+    const updated = await userService.getUserById(admin!.id);
+    expect(updated!.mustChangePassword).toBe(false);
+  });
+
+  it('forces a change for admin-created users, and can be cleared', async () => {
+    await userService.initialize();
+
+    const created = await userService.createUser({
+      username: 'editor1',
+      password: 'initial-password',
+      role: UserRole.EDITOR,
+    });
+
+    const stored = await userService.getUserById(created.id);
+    expect(stored!.mustChangePassword).toBe(true);
+
+    // Admin resetting ANOTHER user's password forces a change (true).
+    await userService.updatePassword(created.id, 'admin-set-temp-pass', true);
+    expect((await userService.getUserById(created.id))!.mustChangePassword).toBe(true);
+
+    // The user then changes it themselves, clearing the flag.
+    await userService.updatePassword(created.id, 'user-chosen-pass');
+    expect((await userService.getUserById(created.id))!.mustChangePassword).toBe(false);
+  });
+});

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -48,6 +48,12 @@ class UserService {
           if (!user.allowedZones) {
             user.allowedZones = [];
           }
+          // Migrate: older records predate mustChangePassword. Default them to
+          // false so an existing deployment is not locked out on upgrade; only
+          // freshly seeded/created accounts carry the forced-change flag.
+          if (user.mustChangePassword === undefined) {
+            user.mustChangePassword = false;
+          }
           this.users.set(user.id, user);
         });
 
@@ -91,6 +97,9 @@ class UserService {
         createdAt: new Date(),
         allowedKeyIds: [],
         allowedZones: [],
+        // Force the operator to rotate the well-known default password before
+        // the account can perform any mutating action.
+        mustChangePassword: true,
       };
 
       this.users.set(user.id, user);
@@ -135,7 +144,9 @@ class UserService {
     // Hash password
     const passwordHash = await bcrypt.hash(userData.password, SALT_ROUNDS);
 
-    // Create user
+    // Create user. The initial password is chosen by the administrator, so we
+    // force the new user to change it on first use before they can mutate
+    // anything (self-service change-password clears the flag).
     const user: User = {
       id: this.generateUserId(),
       username: userData.username,
@@ -145,6 +156,7 @@ class UserService {
       createdAt: new Date(),
       allowedKeyIds: userData.allowedKeyIds || [],
       allowedZones: userData.allowedZones || [],
+      mustChangePassword: true,
     };
 
     this.users.set(user.id, user);
@@ -199,9 +211,16 @@ class UserService {
   }
 
   /**
-   * Update user password
+   * Update user password.
+   *
+   * `mustChangePassword` controls the resulting forced-change flag:
+   * - false (default): the user chose this password themselves (self-service
+   *   change-password or admin resetting their OWN password), so the flag is
+   *   cleared and the account is unblocked.
+   * - true: an administrator set the password for another user, so the target
+   *   is forced to rotate it on first use.
    */
-  async updatePassword(userId: string, newPassword: string): Promise<void> {
+  async updatePassword(userId: string, newPassword: string, mustChangePassword = false): Promise<void> {
     if (!this.initialized) await this.initialize();
 
     const user = this.users.get(userId);
@@ -210,6 +229,7 @@ class UserService {
     }
 
     user.passwordHash = await bcrypt.hash(newPassword, SALT_ROUNDS);
+    user.mustChangePassword = mustChangePassword;
     await this.saveUsers();
   }
 

--- a/backend/src/types/auth.ts
+++ b/backend/src/types/auth.ts
@@ -21,6 +21,11 @@ export interface User {
   allowedKeyIds: string[];
   // Array of zone names this user is restricted to (empty = no restriction)
   allowedZones: string[];
+  // When true, the user must change their password before performing any
+  // mutating action. Set for the seeded default admin and for accounts whose
+  // password was set/reset by an administrator. Optional so SSO users (which
+  // have no local password) and legacy on-disk records omit it entirely.
+  mustChangePassword?: boolean;
 }
 
 // User creation data (without hash)
@@ -51,6 +56,9 @@ export interface SessionData {
   role: UserRole;
   allowedKeyIds: string[];
   allowedZones: string[];
+  // Mirrors User.mustChangePassword so /session can surface it and the
+  // requirePasswordCurrent guard can read it off the request.
+  mustChangePassword?: boolean;
 }
 
 // Extend Express Request to include session data
@@ -61,6 +69,7 @@ declare module 'express-session' {
     role: UserRole;
     allowedKeyIds: string[];
     allowedZones: string[];
+    mustChangePassword?: boolean;
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,9 +10,10 @@ import { AuthProvider, useAuth } from './context/AuthContext';
 import { NotificationProvider } from './context/NotificationContext';
 import AppContent from './components/AppContent';
 import Login from './components/Login';
+import ForcedPasswordChange from './components/ForcedPasswordChange';
 
 function AuthenticatedApp() {
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isAuthenticated, isLoading, mustChangePassword } = useAuth();
 
   if (isLoading) {
     return (
@@ -31,6 +32,11 @@ function AuthenticatedApp() {
 
   if (!isAuthenticated) {
     return <Login />;
+  }
+
+  // Block all app access until a forced password change is completed.
+  if (mustChangePassword) {
+    return <ForcedPasswordChange />;
   }
 
   return (

--- a/src/components/ForcedPasswordChange.tsx
+++ b/src/components/ForcedPasswordChange.tsx
@@ -1,0 +1,160 @@
+// src/components/ForcedPasswordChange.tsx
+// Full-screen gate shown after login when the account still owes a forced
+// password change (seeded default admin, or an admin-set initial password).
+// Blocks the rest of the app until the user changes their password; reuses the
+// same authService.changePassword flow as the in-app Change Password dialog.
+import React, { useState } from 'react';
+import {
+  Box,
+  Paper,
+  TextField,
+  Button,
+  Typography,
+  Alert,
+  CircularProgress,
+  Container,
+} from '@mui/material';
+import { useAuth } from '../context/AuthContext';
+import { authService } from '../services/authService';
+
+export default function ForcedPasswordChange() {
+  const { user, logout, clearMustChangePassword } = useAuth();
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    if (newPassword.length < 8) {
+      setError('New password must be at least 8 characters');
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError('New passwords do not match');
+      return;
+    }
+    if (newPassword === currentPassword) {
+      setError('New password must be different from the current password');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await authService.changePassword(currentPassword, newPassword);
+      if (result.success) {
+        setSuccess('Password changed successfully. Loading application...');
+        // Clearing the flag lets AuthenticatedApp render the full application.
+        clearMustChangePassword();
+      } else {
+        setError(result.error || 'Failed to change password');
+      }
+    } catch {
+      setError('Failed to connect to server');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box
+        sx={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Paper elevation={3} sx={{ p: 4, width: '100%', maxWidth: 420 }}>
+          <Typography variant="h5" component="h1" gutterBottom align="center">
+            Change Your Password
+          </Typography>
+          <Alert severity="warning" sx={{ my: 2 }}>
+            You must change the default password before continuing.
+          </Alert>
+
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {error}
+            </Alert>
+          )}
+          {success && (
+            <Alert severity="success" sx={{ mb: 2 }}>
+              {success}
+            </Alert>
+          )}
+
+          <Box component="form" onSubmit={handleSubmit} noValidate>
+            <TextField
+              margin="normal"
+              required
+              fullWidth
+              label="Current Password"
+              type="password"
+              autoComplete="current-password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              disabled={submitting}
+            />
+            <TextField
+              margin="normal"
+              required
+              fullWidth
+              label="New Password"
+              type="password"
+              autoComplete="new-password"
+              helperText="Must be at least 8 characters"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              disabled={submitting}
+            />
+            <TextField
+              margin="normal"
+              required
+              fullWidth
+              label="Confirm New Password"
+              type="password"
+              autoComplete="new-password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              disabled={submitting}
+            />
+            <Button
+              type="submit"
+              fullWidth
+              variant="contained"
+              sx={{ mt: 3, mb: 1 }}
+              disabled={submitting || !currentPassword || !newPassword || !confirmPassword}
+            >
+              {submitting ? <CircularProgress size={24} /> : 'Change Password'}
+            </Button>
+            <Button
+              fullWidth
+              variant="text"
+              onClick={() => logout()}
+              disabled={submitting}
+            >
+              Sign in as a different user
+            </Button>
+          </Box>
+
+          {user && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ mt: 2, display: 'block', textAlign: 'center' }}
+            >
+              Signed in as {user.username}
+            </Typography>
+          )}
+        </Paper>
+      </Box>
+    </Container>
+  );
+}

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -6,18 +6,24 @@ interface AuthContextType {
   user: User | null;
   isAuthenticated: boolean;
   isLoading: boolean;
+  // True while the authenticated user still owes a forced password change.
+  mustChangePassword: boolean;
   login: (username: string, password: string) => Promise<{ success: boolean; error?: string }>;
   logout: () => Promise<void>;
   checkSession: () => Promise<void>;
+  // Clears the forced-change flag locally after a successful change.
+  clearMustChangePassword: () => void;
 }
 
 const AuthContext = createContext<AuthContextType>({
   user: null,
   isAuthenticated: false,
   isLoading: true,
+  mustChangePassword: false,
   login: async () => ({ success: false }),
   logout: async () => {},
   checkSession: async () => {},
+  clearMustChangePassword: () => {},
 });
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
@@ -75,15 +81,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
+  const clearMustChangePassword = useCallback(() => {
+    setUser((prev) => (prev ? { ...prev, mustChangePassword: false } : prev));
+  }, []);
+
   return (
     <AuthContext.Provider
       value={{
         user,
         isAuthenticated: user !== null,
         isLoading,
+        mustChangePassword: user?.mustChangePassword === true,
         login,
         logout,
         checkSession,
+        clearMustChangePassword,
       }}
     >
       {children}

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -10,6 +10,8 @@ export interface User {
   role: 'admin' | 'editor' | 'viewer';
   email?: string;
   allowedKeyIds: string[];
+  // When true, the user must change their password before using the app.
+  mustChangePassword?: boolean;
 }
 
 export interface LoginResponse {


### PR DESCRIPTION
## Summary

Two approved auth-hardening items (the last of the audit backlog).

**1. Forced default-admin password rotation.** Added `mustChangePassword` to the User model. The seeded `admin`/`changeme123` is flagged true; admin-created users and admin-reset-of-another-user's-password are flagged true; self-service change and admin-reset-of-own clear it; legacy on-disk users migrate to false (no lockout on upgrade). Enforced server-side by a new `requirePasswordCurrent` guard returning `403 PASSWORD_CHANGE_REQUIRED` on every mutation route (zone record writes, TSIG key writes, user CRUD, config writes, and snapshot create); login/logout/session/change-password and all reads stay reachable. The flag is surfaced in the login and session responses, and the frontend renders a full-screen forced-change gate until the user rotates.

**2. Current password required on admin self password-reset.** `PATCH /users/:userId/password` now requires and verifies the current password when an admin resets *their own* password (mirroring `/change-password`); resetting another user's password is unchanged.

Coordinated cleanly with `fix/login-timing` (disjoint `userService` regions — model/seed/updatePassword here, `authenticate()` there) and `fix/sso-hardening`; all four branches merge without conflict, combined tree frontend 236 + backend 285 green.

## Testing

9 new backend tests (seed/clear/force flag transitions, the guard's allow/deny, self-reset-requires-current helper). Backend 259 tests on branch; frontend 236; both builds/typechecks/lint green. No supertest infra, so enforcement is covered at the guard/service level (noted).