### PR TITLE
fix(a11y): WCAG 2.1 AA sweep — labels, landmarks, keyboard reorder

### DIFF
--- a/src/components/AddDNSRecord.tsx
+++ b/src/components/AddDNSRecord.tsx
@@ -10,7 +10,6 @@ import {
   FormControl,
   InputLabel,
   Typography,
-  FormHelperText,
   Grid,
   CircularProgress
 } from '@mui/material';
@@ -656,8 +655,10 @@ function AddDNSRecord({ zone, onSuccess, onClose }: AddDNSRecordProps) {
 
         <Grid item xs={12} sm={6}>
           <FormControl fullWidth>
-            <InputLabel>Record Type</InputLabel>
+            <InputLabel id="record-type-label">Record Type</InputLabel>
             <Select
+              labelId="record-type-label"
+              id="record-type"
               value={record.type}
               onChange={(e) => handleFieldChange('type', e.target.value)}
               label="Record Type"
@@ -679,24 +680,25 @@ function AddDNSRecord({ zone, onSuccess, onClose }: AddDNSRecordProps) {
           return (
             <Grid item xs={12} sm={field.type === 'number' ? 6 : 12} key={field.name}>
               {field.select ? (
-                <FormControl fullWidth error={!!fieldErrors[field.name]}>
-                  <InputLabel>{field.label}</InputLabel>
-                  <Select
-                    value={(record as any)[field.name] || ''}
-                    onChange={(e) => handleFieldChange(field.name, e.target.value)}
-                    label={field.label}
-                  >
-                    {(field.options || []).map((option) => (
-                      <MenuItem
-                        key={typeof option === 'object' ? option.value : option}
-                        value={typeof option === 'object' ? option.value : option}
-                      >
-                        {typeof option === 'object' ? option.label : option}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                  {field.helperText && <FormHelperText>{fieldErrors[field.name] || field.helperText}</FormHelperText>}
-                </FormControl>
+                <TextField
+                  select
+                  fullWidth
+                  id={`add-record-${field.name}`}
+                  label={field.label}
+                  value={(record as any)[field.name] || ''}
+                  onChange={(e) => handleFieldChange(field.name, e.target.value)}
+                  error={!!fieldErrors[field.name]}
+                  helperText={field.helperText ? (fieldErrors[field.name] || field.helperText) : undefined}
+                >
+                  {(field.options || []).map((option) => (
+                    <MenuItem
+                      key={typeof option === 'object' ? option.value : option}
+                      value={typeof option === 'object' ? option.value : option}
+                    >
+                      {typeof option === 'object' ? option.label : option}
+                    </MenuItem>
+                  ))}
+                </TextField>
               ) : (
                 <TextField
                   fullWidth
@@ -780,6 +782,7 @@ function AddDNSRecord({ zone, onSuccess, onClose }: AddDNSRecordProps) {
           variant="contained"
           color="primary"
           disabled={submitting}
+          aria-label={submitting ? 'Adding record' : undefined}
         >
           {submitting ? (
             <CircularProgress size={24} color="inherit" />

--- a/src/components/AuditLog.tsx
+++ b/src/components/AuditLog.tsx
@@ -187,14 +187,14 @@ const AuditLog: React.FC = () => {
         <Box>
           <Tooltip title="Refresh logs">
             <span>
-              <IconButton onClick={loadLogs} disabled={loading}>
+              <IconButton onClick={loadLogs} disabled={loading} aria-label="Refresh logs">
                 <RefreshIcon />
               </IconButton>
             </span>
           </Tooltip>
           <Tooltip title="Export as CSV">
             <span>
-              <IconButton onClick={handleExportCSV} disabled={filteredEntries.length === 0}>
+              <IconButton onClick={handleExportCSV} disabled={filteredEntries.length === 0} aria-label="Export as CSV">
                 <DownloadIcon />
               </IconButton>
             </span>
@@ -310,8 +310,8 @@ const AuditLog: React.FC = () => {
 
       {/* Loading state */}
       {loading ? (
-        <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
-          <CircularProgress />
+        <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }} role="status">
+          <CircularProgress aria-label="Loading" />
         </Box>
       ) : (
         <>

--- a/src/components/ForcedPasswordChange.tsx
+++ b/src/components/ForcedPasswordChange.tsx
@@ -131,6 +131,7 @@ export default function ForcedPasswordChange() {
               variant="contained"
               sx={{ mt: 3, mb: 1 }}
               disabled={submitting || !currentPassword || !newPassword || !confirmPassword}
+              aria-label={submitting ? 'Changing password' : undefined}
             >
               {submitting ? <CircularProgress size={24} /> : 'Change Password'}
             </Button>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,9 +1,9 @@
 // src/components/Layout.tsx
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Box, Typography, IconButton, Divider, Button, Menu, MenuItem, Chip,
   Dialog, DialogTitle, DialogContent, DialogActions, TextField, Alert,
-  CircularProgress, Drawer,
+  CircularProgress, Drawer, Link,
 } from '@mui/material';
 import { useLocation } from 'react-router-dom';
 import {
@@ -106,6 +106,12 @@ function Layout({ children }: { children: React.ReactNode }) {
     }
   };
 
+  // Keep the document title in sync with the current route (WCAG SC 2.4.2).
+  const pageTitle = getPageTitle();
+  useEffect(() => {
+    document.title = pageTitle ? `${pageTitle} - Snap DNS` : 'Snap DNS';
+  }, [pageTitle]);
+
   return (
     <Box sx={{
       display: 'flex',
@@ -113,6 +119,26 @@ function Layout({ children }: { children: React.ReactNode }) {
       bgcolor: 'background.default',
       color: 'text.primary'
     }}>
+      {/* Skip link: visually hidden until focused, lets keyboard users jump
+          straight to the main content (WCAG SC 2.4.1). */}
+      <Link
+        href="#main-content"
+        sx={{
+          position: 'absolute',
+          left: -9999,
+          top: 8,
+          zIndex: (theme) => theme.zIndex.tooltip + 1,
+          p: 1,
+          borderRadius: 1,
+          bgcolor: 'background.paper',
+          color: 'text.primary',
+          '&:focus': {
+            left: 8,
+          },
+        }}
+      >
+        Skip to main content
+      </Link>
       {/* Mobile navigation: temporary drawer toggled by the hamburger button */}
       <Drawer
         variant="temporary"
@@ -141,7 +167,10 @@ function Layout({ children }: { children: React.ReactNode }) {
       >
         <Navigation />
       </Box>
-      <Box sx={{
+      <Box
+        component="main"
+        id="main-content"
+        sx={{
         flexGrow: 1,
         minWidth: 0,
         ml: { xs: 0, md: '240px' },
@@ -166,8 +195,8 @@ function Layout({ children }: { children: React.ReactNode }) {
             >
               <MenuIcon />
             </IconButton>
-            <Typography variant="h6">
-              {getPageTitle()}
+            <Typography variant="h5" component="h1">
+              {pageTitle}
             </Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 2 }}>
@@ -179,7 +208,11 @@ function Layout({ children }: { children: React.ReactNode }) {
             >
               Pending Changes ({pendingChanges.length})
             </Button>
-            <IconButton onClick={toggleDarkMode} color="inherit">
+            <IconButton
+              onClick={toggleDarkMode}
+              color="inherit"
+              aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+            >
               {darkMode ? <Brightness7 /> : <Brightness4 />}
             </IconButton>
             {user && (
@@ -190,6 +223,8 @@ function Layout({ children }: { children: React.ReactNode }) {
                   onClick={handleUserMenuOpen}
                   clickable
                   size="small"
+                  aria-haspopup="true"
+                  aria-expanded={Boolean(anchorEl)}
                 />
                 <Menu
                   anchorEl={anchorEl}

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -159,6 +159,7 @@ export default function Login() {
               variant="contained"
               sx={{ mt: 3, mb: 2 }}
               disabled={isLoading || !username || !password}
+              aria-label={isLoading ? 'Signing in' : undefined}
             >
               {isLoading ? <CircularProgress size={24} /> : 'Sign In'}
             </Button>

--- a/src/components/PendingChangesDrawer.tsx
+++ b/src/components/PendingChangesDrawer.tsx
@@ -29,7 +29,9 @@ import {
   RestoreFromTrash as RestoreIcon,
   DragIndicator,
   KeyboardArrowDown as ExpandMoreIcon,
-  KeyboardArrowUp as ExpandLessIcon
+  KeyboardArrowUp as ExpandLessIcon,
+  ArrowUpward as MoveUpIcon,
+  ArrowDownward as MoveDownIcon
 } from '@mui/icons-material';
 import { dnsService, type BatchChange } from '../services/dnsService';
 import { notificationService } from '../services/notificationService';
@@ -116,6 +118,15 @@ function PendingChangesDrawer({
 
   const handleDragEnd = () => {
     setDraggingIndex(null);
+  };
+
+  // Keyboard-accessible alternative to drag-to-reorder (WCAG SC 2.1.1).
+  const moveChange = (from: number, to: number) => {
+    if (to < 0 || to >= pendingChanges.length) return;
+    const items = Array.from(pendingChanges);
+    const [moved] = items.splice(from, 1);
+    items.splice(to, 0, moved);
+    setPendingChanges(items);
   };
 
   // Group changes by zone; used by both the confirmation dialog and apply
@@ -352,9 +363,32 @@ function PendingChangesDrawer({
                   },
                   pr: 6
                 }}
-                onClick={() => toggleExpanded(change.id)}
               >
                 <DragIndicator sx={{ mr: 1, cursor: 'grab', flexShrink: 0 }} />
+                <Stack sx={{ mr: 1, flexShrink: 0 }}>
+                  <IconButton
+                    size="small"
+                    aria-label="Move up"
+                    disabled={index === 0 || applying}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      moveChange(index, index - 1);
+                    }}
+                  >
+                    <MoveUpIcon fontSize="inherit" />
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    aria-label="Move down"
+                    disabled={index === pendingChanges.length - 1 || applying}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      moveChange(index, index + 1);
+                    }}
+                  >
+                    <MoveDownIcon fontSize="inherit" />
+                  </IconButton>
+                </Stack>
                 <ListItemText
                   sx={{ 
                     mr: 1,
@@ -377,6 +411,8 @@ function PendingChangesDrawer({
                       <Typography component="span" noWrap>{getChangeDescription(change)}</Typography>
                       <IconButton
                         size="small"
+                        aria-label={expandedItems[change.id] ? 'Collapse details' : 'Expand details'}
+                        aria-expanded={Boolean(expandedItems[change.id])}
                         onClick={(e) => {
                           e.stopPropagation();
                           toggleExpanded(change.id);
@@ -484,6 +520,7 @@ function PendingChangesDrawer({
               onClick={() => setConfirmOpen(true)}
               disabled={applying}
               fullWidth
+              aria-label={applying ? 'Applying changes' : undefined}
             >
               {applying ? (
                 <CircularProgress size={24} color="inherit" />

--- a/src/components/SSOConfiguration.tsx
+++ b/src/components/SSOConfiguration.tsx
@@ -161,8 +161,8 @@ function SSOConfiguration() {
 
   if (loading) {
     return (
-      <Box display="flex" justifyContent="center" py={4}>
-        <CircularProgress />
+      <Box display="flex" justifyContent="center" py={4} role="status">
+        <CircularProgress aria-label="Loading" />
       </Box>
     );
   }

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -488,8 +488,10 @@ function Settings() {
 
             <Box sx={{ mt: 3, display: 'flex', flexDirection: 'column', gap: 3 }}>
           <FormControl>
-            <InputLabel>Default TTL</InputLabel>
+            <InputLabel id="default-ttl-label">Default TTL</InputLabel>
             <Select
+              labelId="default-ttl-label"
+              id="default-ttl"
               value={defaultTTL}
               onChange={(e) => setDefaultTTL(Number(e.target.value))}
               label="Default TTL"
@@ -502,8 +504,10 @@ function Settings() {
           </FormControl>
 
           <FormControl>
-            <InputLabel>Notification Provider</InputLabel>
+            <InputLabel id="notification-provider-label">Notification Provider</InputLabel>
             <Select
+              labelId="notification-provider-label"
+              id="notification-provider"
               value={webhookProvider}
               onChange={(e) => setWebhookProvider(e.target.value as WebhookProvider)}
               label="Notification Provider"
@@ -536,8 +540,10 @@ function Settings() {
           />
 
           <FormControl>
-            <InputLabel>Default Rows Per Page</InputLabel>
+            <InputLabel id="rows-per-page-label">Default Rows Per Page</InputLabel>
             <Select
+              labelId="rows-per-page-label"
+              id="rows-per-page"
               value={config.rowsPerPage || 10}
               onChange={(e) => {
                 updateConfig({
@@ -721,8 +727,10 @@ function Settings() {
                   Select a key to associate with the imported zones:
                 </Typography>
                 <FormControl fullWidth sx={{ mt: 2 }}>
-                  <InputLabel>Select Key</InputLabel>
+                  <InputLabel id="import-select-key-label">Select Key</InputLabel>
                   <Select
+                    labelId="import-select-key-label"
+                    id="import-select-key"
                     value={selectedKeyId}
                     onChange={(e) => {
                       setSelectedKeyId(e.target.value);

--- a/src/components/Snapshots.tsx
+++ b/src/components/Snapshots.tsx
@@ -926,6 +926,7 @@ function Snapshots() {
               m: 0,
               p: 1,
               backgroundColor: 'error.light',
+              color: 'error.contrastText',
               borderRadius: 1,
               fontSize: '0.875rem',
               whiteSpace: 'pre-wrap',
@@ -942,6 +943,7 @@ function Snapshots() {
               m: 0,
               p: 1,
               backgroundColor: 'success.light',
+              color: 'success.contrastText',
               borderRadius: 1,
               fontSize: '0.875rem',
               whiteSpace: 'pre-wrap',
@@ -1029,6 +1031,7 @@ function Snapshots() {
               placeholder="Search snapshots..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
+              inputProps={{ 'aria-label': 'Search snapshots' }}
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">
@@ -1083,8 +1086,8 @@ function Snapshots() {
         </Grid>
 
         {loadingBackups ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-            <CircularProgress />
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }} role="status">
+            <CircularProgress aria-label="Loading" />
           </Box>
         ) : Object.entries(groupedBackups).length > 0 ? (
           Object.entries(groupedBackups).map(([date, dateBackups]) => (
@@ -1148,6 +1151,7 @@ function Snapshots() {
                             <Tooltip title="Download snapshot">
                               <IconButton
                                 size="small"
+                                aria-label="Download snapshot"
                                 onClick={() => handleDownloadBackup(backup)}
                               >
                                 <DownloadIcon />
@@ -1156,6 +1160,7 @@ function Snapshots() {
                             <Tooltip title="Compare with current zone">
                               <IconButton
                                 size="small"
+                                aria-label="Compare with current zone"
                                 onClick={() => handleCompareBackup(backup)}
                               >
                                 <CompareIcon />
@@ -1173,6 +1178,7 @@ function Snapshots() {
                             <Tooltip title="Delete snapshot">
                               <IconButton
                                 size="small"
+                                aria-label="Delete snapshot"
                                 onClick={() => handleDeleteBackup(backup)}
                                 color="error"
                               >
@@ -1311,8 +1317,8 @@ function Snapshots() {
         </DialogTitle>
         <DialogContent>
           {loadingComparison ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
-              <CircularProgress />
+            <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }} role="status">
+              <CircularProgress aria-label="Loading" />
             </Box>
           ) : comparisonData ? (
             <Box>
@@ -1358,6 +1364,8 @@ function Snapshots() {
                               <TableCell>
                                 <IconButton
                                   size="small"
+                                  aria-label={expandedRecords[`modified-${index}`] ? 'Collapse changed fields' : 'Expand changed fields'}
+                                  aria-expanded={Boolean(expandedRecords[`modified-${index}`])}
                                   onClick={() => setExpandedRecords(prev => ({
                                     ...prev,
                                     [`modified-${index}`]: !prev[`modified-${index}`]
@@ -1435,6 +1443,7 @@ function Snapshots() {
                                   m: 0,
                                   p: 1,
                                   backgroundColor: 'success.light',
+                                  color: 'success.contrastText',
                                   borderRadius: 1,
                                   fontSize: '0.875rem',
                                   whiteSpace: 'pre-wrap',
@@ -1490,6 +1499,7 @@ function Snapshots() {
                                   m: 0,
                                   p: 1,
                                   backgroundColor: 'error.light',
+                                  color: 'error.contrastText',
                                   borderRadius: 1,
                                   fontSize: '0.875rem',
                                   whiteSpace: 'pre-wrap',

--- a/src/components/TSIGKeyManagement.tsx
+++ b/src/components/TSIGKeyManagement.tsx
@@ -194,8 +194,8 @@ export default function TSIGKeyManagement() {
 
   if (loading) {
     return (
-      <Box display="flex" justifyContent="center" p={3}>
-        <CircularProgress />
+      <Box display="flex" justifyContent="center" p={3} role="status">
+        <CircularProgress aria-label="Loading" />
       </Box>
     );
   }
@@ -375,6 +375,7 @@ export default function TSIGKeyManagement() {
               <Box display="flex" gap={1} mb={1}>
                 <TextField
                   size="small"
+                  aria-label="Add zone"
                   placeholder="example.com"
                   value={zoneInput}
                   onChange={(e) => setZoneInput(e.target.value)}

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -265,8 +265,8 @@ function UserManagement() {
 
   if (loading) {
     return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
-        <CircularProgress />
+      <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px" role="status">
+        <CircularProgress aria-label="Loading" />
       </Box>
     );
   }

--- a/src/components/ZoneEditor.tsx
+++ b/src/components/ZoneEditor.tsx
@@ -571,8 +571,8 @@ function ZoneEditor() {
   if (keysLoading) {
     return (
       <Paper sx={{ p: 3 }}>
-        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
-          <CircularProgress />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }} role="status">
+          <CircularProgress aria-label="Loading" />
         </Box>
       </Paper>
     );
@@ -630,6 +630,7 @@ function ZoneEditor() {
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchInput(e.target.value)}
           placeholder="Search records..."
           size="small"
+          inputProps={{ 'aria-label': 'Search records' }}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">
@@ -645,6 +646,7 @@ function ZoneEditor() {
             onChange={(e) => setFilterType(e.target.value as string)}
             size="small"
             displayEmpty
+            aria-label="Filter by record type"
             SelectDisplayProps={{ id: 'record-type-filter' } as React.HTMLAttributes<HTMLDivElement>}
           >
             <MenuItem value="ALL">All Record Types</MenuItem>
@@ -660,6 +662,7 @@ function ZoneEditor() {
               onClick={loadZoneRecords}
               disabled={!selectedZone || !selectedKey || refreshing}
               size="small"
+              aria-label="Refresh Records"
             >
               {refreshing ? (
                 <CircularProgress size={20} />
@@ -696,7 +699,7 @@ function ZoneEditor() {
       )}
 
       {loading ? (
-        <CircularProgress />
+        <CircularProgress aria-label="Loading" />
       ) : (
         <>
           <Box sx={{ mb: 2, display: 'flex', gap: 2 }}>
@@ -751,7 +754,7 @@ function ZoneEditor() {
                       onChange={handleSelectAllClick}
                     />
                   </TableCell>
-                  <TableCell>
+                  <TableCell sortDirection={orderBy === 'name' ? order : false}>
                     <TableSortLabel
                       active={orderBy === 'name'}
                       direction={orderBy === 'name' ? order : 'asc'}
@@ -760,7 +763,7 @@ function ZoneEditor() {
                       Name
                     </TableSortLabel>
                   </TableCell>
-                  <TableCell>
+                  <TableCell sortDirection={orderBy === 'type' ? order : false}>
                     <TableSortLabel
                       active={orderBy === 'type'}
                       direction={orderBy === 'type' ? order : 'asc'}
@@ -769,7 +772,7 @@ function ZoneEditor() {
                       Type
                     </TableSortLabel>
                   </TableCell>
-                  <TableCell>
+                  <TableCell sortDirection={orderBy === 'value' ? order : false}>
                     <TableSortLabel
                       active={orderBy === 'value'}
                       direction={orderBy === 'value' ? order : 'asc'}
@@ -778,7 +781,7 @@ function ZoneEditor() {
                       Value
                     </TableSortLabel>
                   </TableCell>
-                  <TableCell sx={{ display: { xs: 'none', sm: 'table-cell' } }}>
+                  <TableCell sortDirection={orderBy === 'ttl' ? order : false} sx={{ display: { xs: 'none', sm: 'table-cell' } }}>
                     <TableSortLabel
                       active={orderBy === 'ttl'}
                       direction={orderBy === 'ttl' ? order : 'asc'}

--- a/src/components/editors/DkimEditor.tsx
+++ b/src/components/editors/DkimEditor.tsx
@@ -103,8 +103,10 @@ export default function DkimEditor({ value, onChange }: DkimEditorProps) {
         </Grid>
         <Grid item xs={12} md={4}>
           <FormControl fullWidth size="small">
-            <InputLabel>Algorithm (k)</InputLabel>
+            <InputLabel id="dkim-k-label">Algorithm (k)</InputLabel>
             <Select
+              labelId="dkim-k-label"
+              id="dkim-k"
               value={tags.k}
               onChange={(e) => update({ ...tags, k: e.target.value })}
               label="Algorithm (k)"

--- a/src/components/editors/DmarcEditor.tsx
+++ b/src/components/editors/DmarcEditor.tsx
@@ -106,8 +106,10 @@ export default function DmarcEditor({ value, onChange }: DmarcEditorProps) {
         </Grid>
         <Grid item xs={12} md={4}>
           <FormControl fullWidth size="small">
-            <InputLabel>Policy (p)</InputLabel>
+            <InputLabel id="dmarc-p-label">Policy (p)</InputLabel>
             <Select
+              labelId="dmarc-p-label"
+              id="dmarc-p"
               value={tags.p}
               onChange={(e) => update({ ...tags, p: e.target.value })}
               label="Policy (p)"
@@ -120,8 +122,10 @@ export default function DmarcEditor({ value, onChange }: DmarcEditorProps) {
         </Grid>
         <Grid item xs={12} md={4}>
           <FormControl fullWidth size="small">
-            <InputLabel>Subdomain Policy (sp)</InputLabel>
+            <InputLabel id="dmarc-sp-label">Subdomain Policy (sp)</InputLabel>
             <Select
+              labelId="dmarc-sp-label"
+              id="dmarc-sp"
               value={tags.sp}
               onChange={(e) => update({ ...tags, sp: e.target.value })}
               label="Subdomain Policy (sp)"
@@ -156,7 +160,7 @@ export default function DmarcEditor({ value, onChange }: DmarcEditorProps) {
           />
         </Grid>
         <Grid item xs={12} md={4}>
-          <Typography variant="body2" color="textSecondary" gutterBottom>
+          <Typography id="dmarc-pct-label" variant="body2" color="textSecondary" gutterBottom>
             Percentage (pct): {tags.pct}%
           </Typography>
           <Slider
@@ -166,12 +170,16 @@ export default function DmarcEditor({ value, onChange }: DmarcEditorProps) {
             max={100}
             step={1}
             valueLabelDisplay="auto"
+            aria-label="Percentage (pct)"
+            aria-labelledby="dmarc-pct-label"
           />
         </Grid>
         <Grid item xs={12} md={4}>
           <FormControl fullWidth size="small">
-            <InputLabel>DKIM Alignment (adkim)</InputLabel>
+            <InputLabel id="dmarc-adkim-label">DKIM Alignment (adkim)</InputLabel>
             <Select
+              labelId="dmarc-adkim-label"
+              id="dmarc-adkim"
               value={tags.adkim}
               onChange={(e) => update({ ...tags, adkim: e.target.value })}
               label="DKIM Alignment (adkim)"
@@ -184,8 +192,10 @@ export default function DmarcEditor({ value, onChange }: DmarcEditorProps) {
         </Grid>
         <Grid item xs={12} md={4}>
           <FormControl fullWidth size="small">
-            <InputLabel>SPF Alignment (aspf)</InputLabel>
+            <InputLabel id="dmarc-aspf-label">SPF Alignment (aspf)</InputLabel>
             <Select
+              labelId="dmarc-aspf-label"
+              id="dmarc-aspf"
               value={tags.aspf}
               onChange={(e) => update({ ...tags, aspf: e.target.value })}
               label="SPF Alignment (aspf)"

--- a/src/components/editors/SpfEditor.tsx
+++ b/src/components/editors/SpfEditor.tsx
@@ -121,8 +121,10 @@ export default function SpfEditor({ value, onChange }: SpfEditorProps) {
         <Grid container spacing={1} key={index} sx={{ mb: 1, alignItems: 'center' }}>
           <Grid item xs={2}>
             <FormControl fullWidth size="small">
-              <InputLabel>Qualifier</InputLabel>
+              <InputLabel id={`spf-qualifier-label-${index}`}>Qualifier</InputLabel>
               <Select
+                labelId={`spf-qualifier-label-${index}`}
+                id={`spf-qualifier-${index}`}
                 value={mech.qualifier}
                 onChange={(e) => updateMechanism(index, 'qualifier', e.target.value)}
                 label="Qualifier"
@@ -135,8 +137,10 @@ export default function SpfEditor({ value, onChange }: SpfEditorProps) {
           </Grid>
           <Grid item xs={3}>
             <FormControl fullWidth size="small">
-              <InputLabel>Type</InputLabel>
+              <InputLabel id={`spf-type-label-${index}`}>Type</InputLabel>
               <Select
+                labelId={`spf-type-label-${index}`}
+                id={`spf-type-${index}`}
                 value={mech.type}
                 onChange={(e) => updateMechanism(index, 'type', e.target.value)}
                 label="Type"
@@ -164,13 +168,13 @@ export default function SpfEditor({ value, onChange }: SpfEditorProps) {
             )}
           </Grid>
           <Grid item xs={2} sx={{ display: 'flex' }}>
-            <IconButton size="small" onClick={() => moveMechanism(index, -1)} disabled={index === 0}>
+            <IconButton size="small" aria-label="Move mechanism up" onClick={() => moveMechanism(index, -1)} disabled={index === 0}>
               <ArrowUpwardIcon fontSize="small" />
             </IconButton>
-            <IconButton size="small" onClick={() => moveMechanism(index, 1)} disabled={index === mechanisms.length - 1}>
+            <IconButton size="small" aria-label="Move mechanism down" onClick={() => moveMechanism(index, 1)} disabled={index === mechanisms.length - 1}>
               <ArrowDownwardIcon fontSize="small" />
             </IconButton>
-            <IconButton size="small" onClick={() => removeMechanism(index)} color="error">
+            <IconButton size="small" aria-label="Delete mechanism" onClick={() => removeMechanism(index)} color="error">
               <DeleteIcon fontSize="small" />
             </IconButton>
           </Grid>


### PR DESCRIPTION
## Summary

Acts on the accessibility audit (0 blockers, but 9 serious + 10 moderate + minor). 21 in-scope findings fixed across 15 components; MUI's baseline (dialog focus-trap, `role="alert"` toasts) was already correct and left alone.

- **Keyboard**: PendingChangesDrawer gains Move-up/Move-down buttons as a keyboard alternative to the mouse-only drag reorder (SC 2.1.1); expand toggle gets `aria-label`/`aria-expanded` and the non-focusable row `onClick` is removed.
- **Names for icon buttons**: dark-mode toggle, search/filter inputs, snapshot/audit/zone row-action and refresh/export buttons, SPF/DMARC editor controls — explicit `aria-label`s (SC 4.1.2), mirroring existing tooltips.
- **Select labeling** (SC 1.3.1/4.1.2): the AddDNSRecord dynamic field converted to `<TextField select>` (auto-wires label + error `aria-describedby`, preserving the exact helper-text gating); every other Select (Settings ×4, Record Type, SPF/DKIM/DMARC editors) gets `labelId`/`id` pairing.
- **Page structure**: content becomes `<main id="main-content">`, a focus-visible "Skip to main content" link, per-route `document.title`, and an `<h1>` per page (SC 2.4.1/2.4.2/1.3.1).
- **Feedback**: standalone spinners get `role="status"` + `aria-label="Loading"`; submit buttons keep an accessible name while showing a spinner; diff `<pre>` blocks get `contrastText` so text stays readable in both themes (SC 1.4.3); sortable headers emit `aria-sort`.

Deferred (low value, per plan): native-`title`→`aria-label` churn on already-passing row buttons, and fieldset/legend grouping.

## Testing

`tsc` clean; 236 tests pass (run serially — the `ZoneEditor.perf` debounce benchmark is timing-sensitive under parallel load, unrelated to these aria/semantic changes; each suite passes in isolation); no new eslint warnings; no test assertions needed changing (idle buttons keep their text-based names).