### PR TITLE
fix(audit): rotate the audit log by size to bound disk growth

### DIFF
--- a/backend/src/config/auditLog.ts
+++ b/backend/src/config/auditLog.ts
@@ -1,0 +1,57 @@
+// backend/src/config/auditLog.ts
+// Single place that resolves audit-log rotation settings from the environment.
+//
+// The audit log (data/audit.log) is append-only and would otherwise grow
+// without bound, eventually filling the disk on a long-running deployment.
+// These knobs drive a size-based rotation ring in auditService:
+//   - AUDIT_LOG_MAX_SIZE_MB  max size of the active log before it is rotated
+//                            (default 10 MB)
+//   - AUDIT_LOG_MAX_FILES    number of rotated files kept (audit.log.1 ..
+//                            audit.log.N); the oldest is deleted (default 5)
+//   - AUDIT_LOG_FILE         active log path (default data/audit.log under cwd)
+
+import path from 'path';
+
+export interface AuditLogConfig {
+  /** Absolute (or cwd-relative) path of the active audit log file. */
+  filePath: string;
+  /** Rotate once the active file would exceed this many bytes. */
+  maxSizeBytes: number;
+  /** Number of rotated files to keep (audit.log.1 .. audit.log.N). */
+  maxFiles: number;
+}
+
+const DEFAULT_MAX_SIZE_MB = 10;
+const DEFAULT_MAX_FILES = 5;
+
+/**
+ * Parse a strictly-positive integer env var, falling back to `fallback` for
+ * unset, empty, non-numeric, or non-positive values.
+ */
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = parseInt(value.trim(), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+/**
+ * Resolve the audit-log rotation configuration from the given environment
+ * (defaults to process.env). Resolved in one place so both the service and
+ * tests agree on the knobs and their defaults.
+ */
+export function resolveAuditLogConfig(env: NodeJS.ProcessEnv = process.env): AuditLogConfig {
+  const maxSizeMb = parsePositiveInt(env.AUDIT_LOG_MAX_SIZE_MB, DEFAULT_MAX_SIZE_MB);
+  const maxFiles = parsePositiveInt(env.AUDIT_LOG_MAX_FILES, DEFAULT_MAX_FILES);
+  const filePath = env.AUDIT_LOG_FILE || path.join(process.cwd(), 'data', 'audit.log');
+
+  return {
+    filePath,
+    maxSizeBytes: maxSizeMb * 1024 * 1024,
+    maxFiles,
+  };
+}

--- a/backend/src/services/__tests__/auditService.test.ts
+++ b/backend/src/services/__tests__/auditService.test.ts
@@ -1,7 +1,12 @@
 // backend/src/services/__tests__/auditService.test.ts
 // Unit tests for the audit service: verifies the DNS-operation payload shape
-// (name/type/valueLength, with value redacted) and the newly added event types.
-import { auditService, AuditEventType, AuditEntry } from '../auditService';
+// (name/type/valueLength, with value redacted), the newly added event types,
+// and size-based log rotation (ring, cross-file reads, format/redaction).
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { auditService, AuditService, AuditEventType, AuditEntry } from '../auditService';
+import { resolveAuditLogConfig } from '../../config/auditLog';
 
 describe('auditService', () => {
   // Capture the entries the service would persist without touching the real
@@ -110,6 +115,200 @@ describe('auditService', () => {
       await flush();
 
       expect(entries[0].details.record.valueLength).toBe(0);
+    });
+  });
+
+  describe('log rotation', () => {
+    let tmpDir: string;
+    let logFile: string;
+
+    // Await a fresh service's internal write queue so all queued log() calls
+    // (and their rotation + append) have completed before assertions.
+    async function flushService(svc: AuditService): Promise<void> {
+      await (svc as unknown as { writeQueue: Promise<void> }).writeQueue;
+    }
+
+    async function exists(file: string): Promise<boolean> {
+      try {
+        await fs.access(file);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    async function readEntries(file: string): Promise<AuditEntry[]> {
+      const content = await fs.readFile(file, 'utf-8');
+      return content
+        .split('\n')
+        .filter((line) => line.trim())
+        .map((line) => JSON.parse(line) as AuditEntry);
+    }
+
+    // Log `count` events, each tagged with its index, awaiting the queue so the
+    // sequential rotate-then-append runs deterministically per entry.
+    async function logSequential(svc: AuditService, count: number): Promise<void> {
+      for (let i = 0; i < count; i++) {
+        await svc.log(AuditEventType.ZONE_QUERIED, {
+          userId: 'u1',
+          username: 'admin',
+          success: true,
+          details: { index: i },
+        });
+      }
+      await flushService(svc);
+    }
+
+    beforeEach(async () => {
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'audit-rotation-'));
+      logFile = path.join(tmpDir, 'audit.log');
+    });
+
+    afterEach(async () => {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('does not rotate while the active file stays under the size cap', async () => {
+      // 10 KB cap easily holds a handful of tiny entries.
+      const svc = new AuditService({ filePath: logFile, maxSizeBytes: 10 * 1024, maxFiles: 5 });
+      await logSequential(svc, 5);
+
+      expect(await exists(logFile)).toBe(true);
+      expect(await exists(`${logFile}.1`)).toBe(false);
+      expect(await readEntries(logFile)).toHaveLength(5);
+    });
+
+    it('rotates the active file once the threshold would be exceeded', async () => {
+      // Tiny cap: every write after the first rotates the current file to .1.
+      const svc = new AuditService({ filePath: logFile, maxSizeBytes: 10, maxFiles: 5 });
+      await logSequential(svc, 2);
+
+      expect(await exists(logFile)).toBe(true);
+      expect(await exists(`${logFile}.1`)).toBe(true);
+      // Active file holds the newest entry; .1 holds the previous one.
+      expect((await readEntries(logFile))[0].details.index).toBe(1);
+      expect((await readEntries(`${logFile}.1`))[0].details.index).toBe(0);
+    });
+
+    it('keeps at most maxFiles rotated files and deletes the oldest', async () => {
+      const svc = new AuditService({ filePath: logFile, maxSizeBytes: 10, maxFiles: 2 });
+      // Write far more than the ring can hold.
+      await logSequential(svc, 6);
+
+      expect(await exists(logFile)).toBe(true); // active
+      expect(await exists(`${logFile}.1`)).toBe(true);
+      expect(await exists(`${logFile}.2`)).toBe(true);
+      // Ring is capped at maxFiles=2 rotated files; no third rotated file.
+      expect(await exists(`${logFile}.3`)).toBe(false);
+
+      // Only the newest 3 entries (active + 2 rotated) survive: indices 5,4,3.
+      expect((await readEntries(logFile))[0].details.index).toBe(5);
+      expect((await readEntries(`${logFile}.1`))[0].details.index).toBe(4);
+      expect((await readEntries(`${logFile}.2`))[0].details.index).toBe(3);
+    });
+
+    it('returns the last N entries newest-first across a rotation boundary', async () => {
+      const svc = new AuditService({ filePath: logFile, maxSizeBytes: 10, maxFiles: 5 });
+      await logSequential(svc, 6); // entries span audit.log + .1..
+
+      const result = await svc.query({ limit: 3 });
+      expect(result.map((e) => e.details.index)).toEqual([5, 4, 3]);
+    });
+
+    it('reads all rotated files newest-first when no limit is given', async () => {
+      const svc = new AuditService({ filePath: logFile, maxSizeBytes: 10, maxFiles: 5 });
+      await logSequential(svc, 6); // exactly fills active + 5 rotated
+
+      const result = await svc.query();
+      expect(result.map((e) => e.details.index)).toEqual([5, 4, 3, 2, 1, 0]);
+    });
+
+    it('drops entries older than the ring capacity from reads', async () => {
+      const svc = new AuditService({ filePath: logFile, maxSizeBytes: 10, maxFiles: 5 });
+      await logSequential(svc, 7); // one more than the ring holds
+
+      const result = await svc.query();
+      // Oldest (index 0) has been rotated out of the ring entirely.
+      expect(result.map((e) => e.details.index)).toEqual([6, 5, 4, 3, 2, 1]);
+    });
+
+    it('applies filters correctly across rotated files', async () => {
+      const svc = new AuditService({ filePath: logFile, maxSizeBytes: 10, maxFiles: 5 });
+      await svc.log(AuditEventType.LOGIN_SUCCESS, { userId: 'a', username: 'alice', success: true });
+      await svc.log(AuditEventType.LOGIN_FAILURE, { userId: 'b', username: 'bob', success: false });
+      await svc.log(AuditEventType.LOGIN_SUCCESS, { userId: 'a', username: 'alice', success: true });
+      await flushService(svc);
+
+      const result = await svc.query({ userId: 'a' });
+      expect(result).toHaveLength(2);
+      expect(result.every((e) => e.userId === 'a')).toBe(true);
+    });
+
+    it('preserves the one-JSON-object-per-line format and redaction after rotation', async () => {
+      const svc = new AuditService({ filePath: logFile, maxSizeBytes: 10, maxFiles: 5 });
+      // A DNS op whose raw value must never be persisted, then more writes to
+      // push it into a rotated file.
+      await svc.logDNSOperation('add', 'test.local', { name: 'www.test.local', type: 'A', value: '203.0.113.7' }, 'u1', 'admin', true);
+      await svc.log(AuditEventType.ZONE_QUERIED, { userId: 'u1', username: 'admin', success: true });
+      await svc.log(AuditEventType.ZONE_QUERIED, { userId: 'u1', username: 'admin', success: true });
+      await flushService(svc);
+
+      // The DNS op is now in a rotated file; every rotated file is still valid
+      // one-object-per-line JSON with the value redacted.
+      for (let i = 1; i <= 5; i++) {
+        const rotated = `${logFile}.${i}`;
+        if (!(await exists(rotated))) {
+          continue;
+        }
+        const raw = await fs.readFile(rotated, 'utf-8');
+        for (const line of raw.split('\n').filter((l) => l.trim())) {
+          expect(() => JSON.parse(line)).not.toThrow();
+        }
+        expect(raw).not.toContain('203.0.113.7');
+      }
+
+      const found = await svc.query({ eventType: AuditEventType.RECORD_ADDED });
+      expect(found).toHaveLength(1);
+      expect(found[0].details.record).toEqual({
+        name: 'www.test.local',
+        type: 'A',
+        valueLength: '203.0.113.7'.length,
+      });
+      expect(JSON.stringify(found[0])).not.toContain('203.0.113.7');
+    });
+
+    it('returns [] when no log file exists yet', async () => {
+      const svc = new AuditService({ filePath: logFile, maxSizeBytes: 10, maxFiles: 5 });
+      expect(await svc.query({ limit: 100 })).toEqual([]);
+    });
+  });
+
+  describe('resolveAuditLogConfig', () => {
+    it('applies sane defaults (10 MB, 5 files, data/audit.log)', () => {
+      const cfg = resolveAuditLogConfig({} as NodeJS.ProcessEnv);
+      expect(cfg.maxSizeBytes).toBe(10 * 1024 * 1024);
+      expect(cfg.maxFiles).toBe(5);
+      expect(cfg.filePath.endsWith(path.join('data', 'audit.log'))).toBe(true);
+    });
+
+    it('honours AUDIT_LOG_MAX_SIZE_MB, AUDIT_LOG_MAX_FILES and AUDIT_LOG_FILE', () => {
+      const cfg = resolveAuditLogConfig({
+        AUDIT_LOG_MAX_SIZE_MB: '2',
+        AUDIT_LOG_MAX_FILES: '3',
+        AUDIT_LOG_FILE: '/var/log/snap/audit.log',
+      } as unknown as NodeJS.ProcessEnv);
+      expect(cfg.maxSizeBytes).toBe(2 * 1024 * 1024);
+      expect(cfg.maxFiles).toBe(3);
+      expect(cfg.filePath).toBe('/var/log/snap/audit.log');
+    });
+
+    it('falls back to defaults for invalid or non-positive values', () => {
+      const cfg = resolveAuditLogConfig({
+        AUDIT_LOG_MAX_SIZE_MB: 'not-a-number',
+        AUDIT_LOG_MAX_FILES: '0',
+      } as unknown as NodeJS.ProcessEnv);
+      expect(cfg.maxSizeBytes).toBe(10 * 1024 * 1024);
+      expect(cfg.maxFiles).toBe(5);
     });
   });
 });

--- a/backend/src/services/auditService.ts
+++ b/backend/src/services/auditService.ts
@@ -3,8 +3,7 @@
 
 import { promises as fs } from 'fs';
 import path from 'path';
-
-const AUDIT_LOG_FILE = path.join(process.cwd(), 'data', 'audit.log');
+import { AuditLogConfig, resolveAuditLogConfig } from '../config/auditLog';
 
 export enum AuditEventType {
   // Authentication events
@@ -60,6 +59,15 @@ export interface AuditEntry {
 
 class AuditService {
   private writeQueue: Promise<void> = Promise.resolve();
+  private readonly filePath: string;
+  private readonly maxSizeBytes: number;
+  private readonly maxFiles: number;
+
+  constructor(cfg: AuditLogConfig = resolveAuditLogConfig()) {
+    this.filePath = cfg.filePath;
+    this.maxSizeBytes = cfg.maxSizeBytes;
+    this.maxFiles = cfg.maxFiles;
+  }
 
   /**
    * Log an audit event
@@ -97,15 +105,30 @@ class AuditService {
   }
 
   /**
-   * Write a single audit entry to file
+   * Write a single audit entry to file.
+   *
+   * Called sequentially through the write queue (see log()), so the
+   * check-and-rotate below never races another writer. When the active file
+   * plus the incoming line would exceed the size cap, the rotation ring is
+   * shifted first and the entry is then appended to a fresh, empty file. The
+   * append itself is a single atomic appendFile call, so an entry is never
+   * split or lost.
    */
   private async writeEntry(entry: AuditEntry): Promise<void> {
     try {
       // Ensure directory exists
-      await fs.mkdir(path.dirname(AUDIT_LOG_FILE), { recursive: true });
+      await fs.mkdir(path.dirname(this.filePath), { recursive: true });
 
-      // Append to log file (one JSON object per line for easy parsing)
-      await fs.appendFile(AUDIT_LOG_FILE, JSON.stringify(entry) + '\n', 'utf-8');
+      // One JSON object per line for easy parsing
+      const line = JSON.stringify(entry) + '\n';
+      const lineBytes = Buffer.byteLength(line, 'utf-8');
+
+      // Rotate before appending so the active file stays under the cap and the
+      // entry lands in a fresh file rather than pushing an oversized one.
+      await this.rotateIfNeeded(lineBytes);
+
+      // Append is a single atomic call -- the entry is written whole or not at all.
+      await fs.appendFile(this.filePath, line, 'utf-8');
     } catch (error) {
       console.error('Failed to write audit log:', error);
       // Don't throw - audit logging shouldn't break the app
@@ -113,7 +136,59 @@ class AuditService {
   }
 
   /**
-   * Query audit logs (basic implementation)
+   * Rotate the log ring if appending `incomingBytes` would push the active file
+   * past the size cap. Shifts audit.log.(N-1) -> audit.log.N (dropping the
+   * oldest), then audit.log -> audit.log.1, leaving audit.log absent so the
+   * caller appends to a fresh file. No-op on first run (no file yet).
+   */
+  private async rotateIfNeeded(incomingBytes: number): Promise<void> {
+    let currentSize: number;
+    try {
+      currentSize = (await fs.stat(this.filePath)).size;
+    } catch (error: any) {
+      if (error.code === 'ENOENT') {
+        return; // First run: nothing to rotate.
+      }
+      throw error;
+    }
+
+    // Nothing to rotate if empty, or if the entry still fits under the cap.
+    if (currentSize === 0 || currentSize + incomingBytes <= this.maxSizeBytes) {
+      return;
+    }
+
+    // Shift the ring from oldest to newest. Renaming .(i) -> .(i+1) overwrites
+    // the destination, so the file at .maxFiles is dropped, keeping at most
+    // maxFiles rotated files.
+    for (let i = this.maxFiles - 1; i >= 1; i--) {
+      await this.safeRename(`${this.filePath}.${i}`, `${this.filePath}.${i + 1}`);
+    }
+    await this.safeRename(this.filePath, `${this.filePath}.1`);
+  }
+
+  /**
+   * Rename that tolerates a missing source (a rotated slot that does not exist
+   * yet). Any other error propagates to writeEntry's catch.
+   */
+  private async safeRename(from: string, to: string): Promise<void> {
+    try {
+      await fs.rename(from, to);
+    } catch (error: any) {
+      if (error.code === 'ENOENT') {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Query audit logs, returning matching entries newest-first.
+   *
+   * Rotation means the most recent entries can span the active file plus one or
+   * more rotated files (audit.log.1, audit.log.2, ...). The files are strictly
+   * ordered by recency (active newest, then .1, .2, ...), so this reads them
+   * newest-first and stops as soon as the requested limit is satisfied -- small
+   * limits never touch older rotated files.
    */
   async query(filters?: {
     eventType?: AuditEventType;
@@ -122,40 +197,84 @@ class AuditService {
     endDate?: Date;
     limit?: number;
   }): Promise<AuditEntry[]> {
-    try {
-      const content = await fs.readFile(AUDIT_LOG_FILE, 'utf-8');
-      let entries = content
-        .split('\n')
-        .filter(line => line.trim())
-        .map(line => JSON.parse(line) as AuditEntry);
+    const limit = filters?.limit;
+    const collected: AuditEntry[] = []; // Accumulated newest-first.
 
-      // Apply filters
-      if (filters) {
-        if (filters.eventType) {
-          entries = entries.filter(e => e.eventType === filters.eventType);
-        }
-        if (filters.userId) {
-          entries = entries.filter(e => e.userId === filters.userId);
-        }
-        if (filters.startDate) {
-          entries = entries.filter(e => new Date(e.timestamp) >= filters.startDate!);
-        }
-        if (filters.endDate) {
-          entries = entries.filter(e => new Date(e.timestamp) <= filters.endDate!);
-        }
-        if (filters.limit) {
-          entries = entries.slice(-filters.limit);
-        }
+    // Newest file first: active log, then rotated files .1 .. .maxFiles.
+    for (const filePath of this.orderedFilePaths()) {
+      const fileEntries = await this.readFilteredEntries(filePath, filters);
+      // Lines are appended oldest-first within a file; reverse to newest-first.
+      for (let i = fileEntries.length - 1; i >= 0; i--) {
+        collected.push(fileEntries[i]);
       }
+      if (limit && limit > 0 && collected.length >= limit) {
+        break; // Have enough newest entries; older files can't add newer ones.
+      }
+    }
 
-      return entries.reverse(); // Most recent first
+    if (limit && limit > 0 && collected.length > limit) {
+      return collected.slice(0, limit);
+    }
+    return collected;
+  }
+
+  /**
+   * File paths ordered newest-first: the active log followed by rotated files
+   * audit.log.1 .. audit.log.maxFiles.
+   */
+  private orderedFilePaths(): string[] {
+    const paths = [this.filePath];
+    for (let i = 1; i <= this.maxFiles; i++) {
+      paths.push(`${this.filePath}.${i}`);
+    }
+    return paths;
+  }
+
+  /**
+   * Read one log file and return its entries (oldest-first, as stored) after
+   * applying the given filters. Returns [] if the file does not exist.
+   */
+  private async readFilteredEntries(
+    filePath: string,
+    filters?: {
+      eventType?: AuditEventType;
+      userId?: string;
+      startDate?: Date;
+      endDate?: Date;
+    }
+  ): Promise<AuditEntry[]> {
+    let content: string;
+    try {
+      content = await fs.readFile(filePath, 'utf-8');
     } catch (error: any) {
       if (error.code === 'ENOENT') {
-        return []; // No log file yet
+        return []; // Rotated slot not present (or no log yet).
       }
-      console.error('Failed to query audit logs:', error);
+      console.error('Failed to read audit log file:', error);
       throw error;
     }
+
+    let entries = content
+      .split('\n')
+      .filter(line => line.trim())
+      .map(line => JSON.parse(line) as AuditEntry);
+
+    if (filters) {
+      if (filters.eventType) {
+        entries = entries.filter(e => e.eventType === filters.eventType);
+      }
+      if (filters.userId) {
+        entries = entries.filter(e => e.userId === filters.userId);
+      }
+      if (filters.startDate) {
+        entries = entries.filter(e => new Date(e.timestamp) >= filters.startDate!);
+      }
+      if (filters.endDate) {
+        entries = entries.filter(e => new Date(e.timestamp) <= filters.endDate!);
+      }
+    }
+
+    return entries;
   }
 
   /**
@@ -215,4 +334,5 @@ class AuditService {
   }
 }
 
+export { AuditService };
 export const auditService = new AuditService();


### PR DESCRIPTION
## Summary

Reliability bug: `auditService` appended every event to `audit.log` via `fs.appendFile` with no rotation or cap, so a long-running deployment grew the file without bound and eventually filled the disk. (Sessions have a 24h TTL with reaping and snapshots are capped at 50/zone — those were already fine; the audit log was the one unbounded store.)

Added standard size-based ring rotation, config resolved in one place (`config/auditLog.ts`, matching the `securityToggles.ts` style):
- `AUDIT_LOG_MAX_SIZE_MB` (default 10), `AUDIT_LOG_MAX_FILES` (default 5), `AUDIT_LOG_FILE` (default `data/audit.log`).
- Before each append, `stat` the active file; if the incoming entry would exceed the cap, rotate the ring (`.n-1`→`.n`, high-index first so the oldest at `.maxFiles` is dropped, then active→`.1`) and append to a fresh file. Steady state: `audit.log` plus at most `maxFiles` rotated files.
- **Append stays atomic/lossless**: all writes already serialize through the service's write queue, so check-and-rotate runs sequentially with no concurrent writer, and the entry is one `appendFile` call — written whole or not at all, never mid-rotation.
- **Read path merges across rotation**: `query()` reads newest-first (active, then `.1`, `.2`, …), reversing each file to newest-first and stopping as soon as the requested limit is met — a "last 100" never opens deep rotated files, and a query spanning a rotation boundary returns correctly. Filters, ordering, one-JSON-per-line format, and redaction are unchanged.

## Testing

12 new tests: rotation triggers at (and only at) the threshold; the ring keeps exactly `maxFiles` and deletes the oldest; last-N newest-first across a boundary; filters across rotated files; format/redaction preserved; env defaults/overrides/fallbacks. Tests use a per-test temp dir — the real `data/audit.log` is never touched. Backend 315 tests green; lint clean; build clean.