### PR TITLE
fix(deploy): wire TSIG_ENCRYPTION_KEY into prod compose

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -3,13 +3,19 @@
 # Copy to .env and edit, then run:  docker compose -f docker-compose.prod.yml up -d
 #
 #   cp .env.production.example .env
-#   # set SESSION_SECRET (required) and the public URLs below
+#   # set SESSION_SECRET + TSIG_ENCRYPTION_KEY (required) and the public URLs below
 #   docker compose -f docker-compose.prod.yml up -d
 
 # ── Required ────────────────────────────────────────────────────────
 # Session signing secret. The stack will refuse to start without it.
 # Generate one with:  openssl rand -base64 32
 SESSION_SECRET=
+
+# Encryption key for TSIG keys stored at rest. The backend will refuse to
+# start without it in production. Generate one with:  openssl rand -base64 32
+# Keep it STABLE once set: it is scrypt-derived with a fixed salt, so changing
+# it makes already-stored TSIG keys unreadable (you would have to re-enter them).
+TSIG_ENCRYPTION_KEY=
 
 # ── Image / ports ───────────────────────────────────────────────────
 # Pre-built image tag to pull from ghcr.io (e.g. latest, 2.1.0).

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ The production stack is two containers (frontend + backend). Configure once, the
 ```bash
 cp .env.production.example .env
 # Edit .env and set at least:
-#   SESSION_SECRET   — generate with:  openssl rand -base64 32
+#   SESSION_SECRET      — generate with:  openssl rand -base64 32
+#   TSIG_ENCRYPTION_KEY — generate with:  openssl rand -base64 32  (keep it stable)
 #   REACT_APP_API_URL / ALLOWED_ORIGINS — how the app is reached (see comments in the file)
 ```
 
@@ -88,7 +89,7 @@ docker compose -f docker-compose.prod.yml up -d --build
 **3. Access** the UI at <http://localhost:3001> (or your `FRONTEND_PORT`).
 First login is `admin` / `changeme123` — **change it immediately** in Settings.
 
-> The stack refuses to start if `SESSION_SECRET` is unset and tells you exactly what to do.
+> The stack refuses to start if `SESSION_SECRET` or `TSIG_ENCRYPTION_KEY` is unset and tells you exactly what to do.
 > Pin a released version by setting `IMAGE_TAG` in `.env` (e.g. `IMAGE_TAG=2.1.0`); defaults to `latest`.
 
 **Behind a reverse proxy (HTTPS, recommended):** set `REACT_APP_API_URL` and `ALLOWED_ORIGINS`

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,7 +1,7 @@
 # docker-compose.prod.yml
 # Production stack. Configure once, then run.
 #
-#   cp .env.production.example .env      # set SESSION_SECRET + public URLs
+#   cp .env.production.example .env      # set SESSION_SECRET, TSIG_ENCRYPTION_KEY + public URLs
 #
 # Run with pre-built images from ghcr.io (fastest):
 #   docker compose -f docker-compose.prod.yml up -d
@@ -69,6 +69,11 @@ services:
       # Required — the stack refuses to start without it.
       # Generate with: openssl rand -base64 32
       - "SESSION_SECRET=${SESSION_SECRET:?required - copy .env.production.example to .env and set it}"
+      # Required — encrypts TSIG keys at rest; the backend refuses to start
+      # without it in production. Keep this value STABLE: it is scrypt-derived
+      # with a fixed salt, so changing it makes already-stored keys unreadable.
+      # Generate with: openssl rand -base64 32
+      - "TSIG_ENCRYPTION_KEY=${TSIG_ENCRYPTION_KEY:?required - copy .env.production.example to .env and set it}"
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3001}
       - MAX_REQUEST_SIZE=${MAX_REQUEST_SIZE:-10mb}
       - MAX_ZONE_RECORDS=${MAX_ZONE_RECORDS:-10000}

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -262,7 +262,7 @@ NODE_ENV=development
 - Use strong, unique passwords (minimum 8 characters)
 - Change default admin password immediately
 - Use HTTPS in production
-- Set a strong SESSION_SECRET (use `openssl rand -base64 32`)
+- Set a strong SESSION_SECRET and TSIG_ENCRYPTION_KEY (each: `openssl rand -base64 32`); keep TSIG_ENCRYPTION_KEY stable or stored keys become unreadable
 - Regularly audit user accounts and permissions
 - Monitor failed login attempts
 


### PR DESCRIPTION
## Summary

Packaging gap that breaks production boot. PR #41 made a missing `TSIG_ENCRYPTION_KEY` fatal under `NODE_ENV=production` (so a forgotten key can't silently fall back to the source-public dev default), but `docker-compose.prod.yml` was never updated to pass the variable through.

The prod backend uses an **explicit `environment:` list**, so only listed vars reach the container — and there's no `env_file:` or `backend/.env` mount, so `server.ts`'s `dotenv.config()` (looking for `/app/.env*`, which isn't present) is a dead end in prod. The compose list is the only injection path, and it wired `SESSION_SECRET` but not `TSIG_ENCRYPTION_KEY`. Result: a value set in the compose-level `.env` never reached the container, and the backend threw at boot.

Fix (compose + docs only, no code):
- Add `TSIG_ENCRYPTION_KEY` to the prod backend `environment:` with the same fail-loud `${VAR:?required…}` guard as `SESSION_SECRET`, so a missing value fails at `compose config` time with a clear message instead of a cryptic backend crash.
- Document it in `.env.production.example`, README quickstart, and `docs/AUTHENTICATION.md`, including the **stability caveat**: the key is scrypt-derived with a fixed salt, so changing it makes already-stored TSIG keys unreadable.

## Testing

`docker compose -f docker-compose.prod.yml config` verified both ways: **errors** with the guidance message when `TSIG_ENCRYPTION_KEY` is unset (the boot-fail we're preventing, now caught at config time), and **parses + injects** the var when set. No application code changed.