### PR TITLE
fix(auth): deny-by-default key/zone allowlists (3.0.0, breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.0.0] - 2026-07-13
+
+### ⚠️ Breaking Changes
+
+- **Per-user zone access is now deny-by-default.** An empty `allowedZones` list
+  previously granted a non-admin user access to **all** zones; it now grants
+  access to **no** zones, matching the existing deny-by-default semantics of
+  `allowedKeyIds`. Admins are unaffected (they bypass the zone gate).
+
+  **Upgrade action required:** before or immediately after upgrading, review every
+  non-admin (editor/viewer) user. Any such user who relied on an empty
+  `allowedZones` to reach zones must have their zones assigned explicitly in
+  Settings → Users, or they will be denied access to all zones. New SSO users are
+  created with an empty `allowedZones`, so they also require explicit zone grants.
+
+  A key's own `zones: []` still means "this key is valid for all zones" — that is
+  an admin-configured key capability, not a per-user access grant, and is
+  unchanged.
+
+### Security
+
+- **Fixed a TSIG key metadata leak in the key listing.** `GET /api/tsig-keys`
+  filtered the returned keys only when the caller's allowlist was non-empty, so a
+  non-admin editor/viewer with an empty `allowedKeyIds` received every key's
+  metadata (name, server, key name, algorithm, zones). Secrets were never exposed.
+  The list path now applies a provided allowlist even when empty (empty → sees
+  nothing), consistent with the key-use path (`getKeyForZone`).
+
+[3.0.0]: https://github.com/ttpears/snap-dns/releases/tag/v3.0.0

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "dependencies": {
         "@azure/msal-node": "^3.8.3",
         "bcrypt": "^5.1.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "main": "dist/server.js",
   "scripts": {
     "start": "node dist/server.js",

--- a/backend/src/__tests__/integration/allowlistSemantics.integration.test.ts
+++ b/backend/src/__tests__/integration/allowlistSemantics.integration.test.ts
@@ -1,0 +1,116 @@
+// backend/src/__tests__/integration/allowlistSemantics.integration.test.ts
+// Empty-set semantics for the two per-user allowlists must be deny-by-default and
+// consistent between the "use" path and the "list" path:
+//   - allowedKeyIds: [] => the user may neither use nor even see any key's metadata
+//   - allowedZones:  [] => the user may not access any zone
+// Regression coverage for two footguns:
+//   #1 allowedZones empty formerly meant "all zones" (inverted vs allowedKeyIds).
+//   #2 listKeys skipped filtering on an empty list, so a key-less non-admin saw
+//      every key's metadata (name/server/keyName/algorithm/zones) in the listing.
+import type { Express } from 'express';
+import { buildTestApp, seedUser, loginAgent } from './testApp';
+import { UserRole } from '../../types/auth';
+import { dnsService } from '../../services/dnsService';
+
+const keyBody = (name: string, zones: string[]) => ({
+  name,
+  server: '192.0.2.53',
+  keyName: `${name}.`,
+  keyValue: 'c25hcC1kbnMtdGVzdC1rZXk=',
+  algorithm: 'hmac-sha256',
+  zones,
+});
+
+describe('Allowlist empty-set semantics (deny-by-default)', () => {
+  let app: Express;
+  let keyAId: string;
+  let keyBId: string;
+
+  beforeAll(async () => {
+    app = buildTestApp();
+    await seedUser({ username: 'admin1', password: 'admin-pass-123', role: UserRole.ADMIN });
+    // Admin creates two keys the non-admins may or may not be allowed to see.
+    const { agent } = await loginAgent(app, 'admin1', 'admin-pass-123');
+    const a = await agent.post('/api/tsig-keys').send(keyBody('key-a', ['example.com']));
+    const b = await agent.post('/api/tsig-keys').send(keyBody('key-b', ['example.net']));
+    keyAId = a.body.key.id;
+    keyBId = b.body.key.id;
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('footgun #2: listKeys must not leak metadata to a key-less user', () => {
+    it('a non-admin with empty allowedKeyIds sees no keys', async () => {
+      await seedUser({
+        username: 'nokeys',
+        password: 'nokeys-pass-123',
+        role: UserRole.EDITOR,
+        allowedKeyIds: [],
+      });
+      const { agent } = await loginAgent(app, 'nokeys', 'nokeys-pass-123');
+      const res = await agent.get('/api/tsig-keys');
+      expect(res.status).toBe(200);
+      expect(res.body.keys).toEqual([]);
+    });
+
+    it('a non-admin sees only their allowed keys', async () => {
+      await seedUser({
+        username: 'onekey',
+        password: 'onekey-pass-123',
+        role: UserRole.EDITOR,
+        allowedKeyIds: [keyAId],
+      });
+      const { agent } = await loginAgent(app, 'onekey', 'onekey-pass-123');
+      const res = await agent.get('/api/tsig-keys');
+      expect(res.status).toBe(200);
+      expect(res.body.keys.map((k: { id: string }) => k.id)).toEqual([keyAId]);
+    });
+
+    it('an admin still sees all keys', async () => {
+      const { agent } = await loginAgent(app, 'admin1', 'admin-pass-123');
+      const res = await agent.get('/api/tsig-keys');
+      const ids = res.body.keys.map((k: { id: string }) => k.id);
+      expect(ids).toEqual(expect.arrayContaining([keyAId, keyBId]));
+    });
+  });
+
+  describe('footgun #1: empty allowedZones must deny (not grant) zone access', () => {
+    it('a non-admin with empty allowedZones is denied a zone', async () => {
+      await seedUser({
+        username: 'nozones',
+        password: 'nozones-pass-123',
+        role: UserRole.EDITOR,
+        allowedZones: [],
+        allowedKeyIds: [keyAId],
+      });
+      const { agent } = await loginAgent(app, 'nozones', 'nozones-pass-123');
+      const res = await agent.get('/api/zones/example.com');
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('PERMISSION_DENIED');
+    });
+
+    it('a non-admin with the zone explicitly allowed passes the zone gate', async () => {
+      // Stub the DNS exec layer so a passing gate does not hit real BIND.
+      jest.spyOn(dnsService, 'fetchZoneRecords').mockResolvedValue([] as never);
+      await seedUser({
+        username: 'okzone',
+        password: 'okzone-pass-123',
+        role: UserRole.EDITOR,
+        allowedZones: ['example.com'],
+        allowedKeyIds: [keyAId],
+      });
+      const { agent } = await loginAgent(app, 'okzone', 'okzone-pass-123');
+      const res = await agent.get('/api/zones/example.com');
+      expect(res.status).toBe(200);
+      expect(res.body.code).not.toBe('PERMISSION_DENIED');
+    });
+
+    it('an admin is unaffected by empty allowedZones', async () => {
+      // admin1 has empty allowedZones but the admin role bypasses the gate.
+      jest.spyOn(dnsService, 'fetchZoneRecords').mockResolvedValue([] as never);
+      const { agent } = await loginAgent(app, 'admin1', 'admin-pass-123');
+      const res = await agent.get('/api/zones/example.com');
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/backend/src/__tests__/integration/rbac.integration.test.ts
+++ b/backend/src/__tests__/integration/rbac.integration.test.ts
@@ -32,7 +32,8 @@ describe('RBAC on mutation routes (HTTP)', () => {
   beforeAll(async () => {
     app = buildTestApp();
     await seedUser({ username: 'viewer1', password: 'viewer-pass-123', role: UserRole.VIEWER });
-    await seedUser({ username: 'editor1', password: 'editor-pass-123', role: UserRole.EDITOR });
+    // Grant the zone explicitly: allowedZones is deny-by-default (empty => no zones).
+    await seedUser({ username: 'editor1', password: 'editor-pass-123', role: UserRole.EDITOR, allowedZones: ['example.com'] });
   });
 
   describe('TSIG key creation', () => {

--- a/backend/src/routes/zoneRoutes.ts
+++ b/backend/src/routes/zoneRoutes.ts
@@ -14,14 +14,14 @@ import { BatchChange } from '../services/dnsService';
 
 const router = Router();
 
-// Fetch allowedZones from DB on each request so changes take effect without re-login
+// Fetch allowedZones from DB on each request so changes take effect without re-login.
+// Deny-by-default: a non-admin with no allowedZones may access no zone (consistent
+// with allowedKeyIds). Admins bypass the gate entirely.
 async function checkZoneAccess(user: { role: string; userId: string }, zone: string): Promise<boolean> {
   if (user.role === 'admin') return true;
   const dbUser = await userService.getUserById(user.userId);
   if (!dbUser) return false;
-  const allowedZones = dbUser.allowedZones;
-  if (allowedZones.length === 0) return true;
-  return allowedZones.some(z => z.toLowerCase() === zone.toLowerCase());
+  return dbUser.allowedZones.some(z => z.toLowerCase() === zone.toLowerCase());
 }
 
 // Add custom error types

--- a/backend/src/services/tsigKeyService.ts
+++ b/backend/src/services/tsigKeyService.ts
@@ -201,8 +201,10 @@ class TSIGKeyService {
 
     let keysArray = Array.from(this.keys.values());
 
-    // Filter by allowed keys if provided
-    if (allowedKeyIds && allowedKeyIds.length > 0) {
+    // Deny-by-default: an allowlist that is *provided* is always applied, even when
+    // empty (empty => sees nothing), matching getKeyForZone's use-path semantics.
+    // Callers that should see every key (admins) pass no allowlist (undefined).
+    if (allowedKeyIds) {
       keysArray = keysArray.filter(k => allowedKeyIds.includes(k.id));
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snap-dns",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snap-dns",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snap-dns",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -334,7 +334,7 @@ function UserManagement() {
                   {user.role === 'admin' ? (
                     <Chip label="All Zones" size="small" color="success" />
                   ) : !user.allowedZones || user.allowedZones.length === 0 ? (
-                    <Chip label="All Zones" size="small" color="default" />
+                    <Chip label="No Zones" size="small" />
                   ) : (
                     <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
                       {user.allowedZones.map(z => (
@@ -471,7 +471,7 @@ function UserManagement() {
                 </Typography>
               )}
               <FormHelperText>
-                Leave all unchecked to allow access to all zones covered by the assigned keys
+                Select every zone this user may access. Leaving all unchecked grants no zone access.
               </FormHelperText>
             </Box>
           )}
@@ -560,7 +560,7 @@ function UserManagement() {
                 </Typography>
               )}
               <FormHelperText>
-                Leave all unchecked to allow access to all zones covered by the assigned keys
+                Select every zone this user may access. Leaving all unchecked grants no zone access.
               </FormHelperText>
             </Box>
           )}


### PR DESCRIPTION
## Summary

Fixes two allowlist footguns with inverted empty-set semantics:

- **Metadata leak (security):** `listKeys()` only filtered when the caller's allowlist was non-empty, so a non-admin with empty `allowedKeyIds` saw every key's metadata (name, server, keyName, algorithm, zones) via `GET /api/tsig-keys`. Secrets were never exposed. Now a *provided* allowlist is always applied (empty → sees nothing), matching the use path `getKeyForZone`.
- **Inverted zone access:** `checkZoneAccess()` treated empty `allowedZones` as "all zones" — the opposite of `allowedKeyIds`. Now deny-by-default: empty → no zones. Admins still bypass the gate. A key's own `zones: []` (valid-for-all-zones capability) is unchanged.

Also corrects the `UserManagement` UI (now shows a "No Zones" chip and accurate helper text instead of implying empty = all zones).

## ⚠️ Breaking change

Non-admin (editor/viewer) users relying on an empty `allowedZones` to reach zones lose access until an admin assigns zones explicitly (Settings → Users). New SSO users start with empty `allowedZones` and also need explicit grants. Released as **3.0.0**; see `CHANGELOG.md`.

## Tests

- New `allowlistSemantics.integration.test.ts` (6 HTTP-level tests) — failed before the fix, passes after.
- Updated the RBAC integration test that had seeded an editor with empty `allowedZones` (relied on the old empty=all behavior).
- Full backend suite: 321/321 pass. `tsc` build clean, lint 0 errors. Frontend `tsc --noEmit` clean.