### PR TITLE
feat(ui): reverse-zone sub-selection in KeySelector (3.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-07-13
+
+### Added
+
+- **Reverse-zone sub-selection in the TSIG Key Selection panel.** When the zone
+  list contains more than 5 reverse zones (`.in-addr.arpa` / `.ip6.arpa`), they
+  are collapsed behind a single "Reverse zones (N)…" entry in the main zone
+  dropdown; choosing it reveals a dedicated reverse-zone dropdown. This keeps
+  forward zones easy to find when many reverse zones are present. At 5 or fewer
+  reverse zones the list is unchanged (all zones inline). The three key/zone
+  selects also gained proper label associations for accessibility.
+
 ## [3.0.0] - 2026-07-13
 
 ### ⚠️ Breaking Changes
@@ -33,4 +45,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The list path now applies a provided allowlist even when empty (empty → sees
   nothing), consistent with the key-use path (`getKeyForZone`).
 
+[3.1.0]: https://github.com/ttpears/snap-dns/releases/tag/v3.1.0
 [3.0.0]: https://github.com/ttpears/snap-dns/releases/tag/v3.0.0

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dependencies": {
         "@azure/msal-node": "^3.8.3",
         "bcrypt": "^5.1.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "main": "dist/server.js",
   "scripts": {
     "start": "node dist/server.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snap-dns",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snap-dns",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snap-dns",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/src/components/KeySelector.tsx
+++ b/src/components/KeySelector.tsx
@@ -13,18 +13,28 @@ import {
   FormHelperText
 } from '@mui/material';
 import { useKey } from '../context/KeyContext';
+import { isReverseZone } from '../services/dnsRecordFormatter';
 import SearchIcon from '@mui/icons-material/Search';
 
+// Sentinel option value in the main zone dropdown that opens the reverse-zone
+// sub-selection instead of committing a zone. Cannot collide with a real zone.
+const REVERSE_SENTINEL = '__REVERSE_ZONES__';
+// Above this many reverse zones, collapse them behind the sub-selection so they
+// don't flood the main zone list.
+const REVERSE_GROUP_THRESHOLD = 5;
+
 function KeySelector() {
-  const { 
-    selectedKey, 
-    selectedZone, 
-    selectKey, 
-    selectZone, 
-    availableZones, 
-    availableKeys 
+  const {
+    selectedKey,
+    selectedZone,
+    selectKey,
+    selectZone,
+    availableZones,
+    availableKeys
   } = useKey();
   const [zoneFilter, setZoneFilter] = useState('');
+  // Whether the reverse sub-dropdown is revealed after choosing the sentinel.
+  const [reverseOpen, setReverseOpen] = useState(false);
 
   // Sort zones: numeric first, then alphabetical
   const sortedZones = useMemo(() => {
@@ -51,11 +61,27 @@ function KeySelector() {
   // Validate selected zone is in available zones
   const validSelectedZone = selectedZone && availableZones.includes(selectedZone) ? selectedZone : '';
 
+  // Zones actually shown in the dropdown: the sorted/filtered list narrowed to
+  // the selected key (if any). Partition into forward and reverse groups.
+  const visibleZones = useMemo(
+    () => filteredZones.filter(zone => !selectedKey || selectedKey.zones?.includes(zone)),
+    [filteredZones, selectedKey]
+  );
+  const forwardZones = useMemo(() => visibleZones.filter(z => !isReverseZone(z)), [visibleZones]);
+  const reverseZones = useMemo(() => visibleZones.filter(z => isReverseZone(z)), [visibleZones]);
+
+  // Only collapse reverse zones into a sub-selection once there are enough of
+  // them to be worth hiding; otherwise they stay inline in the main dropdown.
+  const groupReverse = reverseZones.length > REVERSE_GROUP_THRESHOLD;
+  const selectedIsReverse = !!validSelectedZone && isReverseZone(validSelectedZone);
+  const showReverseSelect = groupReverse && (reverseOpen || selectedIsReverse);
+
   const renderKeyOptions = () => {
     return (
       <FormControl fullWidth>
-        <InputLabel>Select Key</InputLabel>
+        <InputLabel id="key-select-label">Select Key</InputLabel>
         <Select
+          labelId="key-select-label"
           value={selectedKey?.id || ''}
           onChange={(e) => {
             const key = availableKeys.find(k => k.id === e.target.value);
@@ -130,23 +156,36 @@ function KeySelector() {
       )}
 
       <FormControl fullWidth>
-        <InputLabel>Select Zone</InputLabel>
+        <InputLabel id="zone-select-label">Select Zone</InputLabel>
         <Select
-          value={validSelectedZone}
-          onChange={(e) => selectZone(e.target.value || null)}
+          labelId="zone-select-label"
+          value={groupReverse && selectedIsReverse ? REVERSE_SENTINEL : validSelectedZone}
+          onChange={(e) => {
+            const value = e.target.value;
+            if (value === REVERSE_SENTINEL) {
+              // Reveal the sub-selection without committing a zone.
+              setReverseOpen(true);
+              return;
+            }
+            setReverseOpen(false);
+            selectZone(value || null);
+          }}
           label="Select Zone"
           SelectDisplayProps={{ id: 'zone-select' } as React.HTMLAttributes<HTMLDivElement>}
         >
           <MenuItem value="">
             <em>None</em>
           </MenuItem>
-          {filteredZones
-            .filter(zone => !selectedKey || selectedKey.zones?.includes(zone))
-            .map((zone) => (
-              <MenuItem key={zone} value={zone}>
-                {zone}
-              </MenuItem>
-            ))}
+          {(groupReverse ? forwardZones : visibleZones).map((zone) => (
+            <MenuItem key={zone} value={zone}>
+              {zone}
+            </MenuItem>
+          ))}
+          {groupReverse && (
+            <MenuItem value={REVERSE_SENTINEL}>
+              Reverse zones ({reverseZones.length})…
+            </MenuItem>
+          )}
         </Select>
         <FormHelperText>
           {validSelectedZone
@@ -156,6 +195,28 @@ function KeySelector() {
               : 'Select a zone to manage'}
         </FormHelperText>
       </FormControl>
+
+      {showReverseSelect && (
+        <FormControl fullWidth>
+          <InputLabel id="reverse-zone-select-label">Reverse Zone</InputLabel>
+          <Select
+            labelId="reverse-zone-select-label"
+            value={selectedIsReverse ? validSelectedZone : ''}
+            onChange={(e) => selectZone(e.target.value || null)}
+            label="Reverse Zone"
+            SelectDisplayProps={{ id: 'reverse-zone-select' } as React.HTMLAttributes<HTMLDivElement>}
+          >
+            <MenuItem value="">
+              <em>None</em>
+            </MenuItem>
+            {reverseZones.map((zone) => (
+              <MenuItem key={zone} value={zone}>
+                {zone}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      )}
 
       {selectedKey && (
         <Typography 

--- a/src/components/__tests__/KeySelector.test.tsx
+++ b/src/components/__tests__/KeySelector.test.tsx
@@ -1,0 +1,87 @@
+// src/components/__tests__/KeySelector.test.tsx
+import React from 'react';
+import { render, screen, within, fireEvent } from '@testing-library/react';
+import KeySelector from '../KeySelector';
+
+const mockUseKey = jest.fn();
+jest.mock('../../context/KeyContext', () => ({
+  useKey: () => mockUseKey()
+}));
+
+const FORWARD = ['example.com', 'example.net'];
+const reverseZones = (n: number) =>
+  Array.from({ length: n }, (_, i) => `${i}.0.192.in-addr.arpa`);
+
+function setup(overrides: Record<string, unknown> = {}) {
+  const selectZone = jest.fn();
+  mockUseKey.mockReturnValue({
+    selectedKey: null,
+    selectedZone: null,
+    selectKey: jest.fn(),
+    selectZone,
+    availableKeys: [],
+    availableZones: [],
+    ...overrides
+  });
+  render(<KeySelector />);
+  return { selectZone };
+}
+
+// Open a MUI Select identified by its accessible name and return a `within`
+// scoped to the resulting listbox.
+function openSelect(name: RegExp) {
+  fireEvent.mouseDown(screen.getByRole('combobox', { name }));
+  return within(screen.getByRole('listbox'));
+}
+
+describe('KeySelector reverse-zone sub-selection', () => {
+  beforeEach(() => mockUseKey.mockReset());
+
+  it('lists reverse zones inline when there are 5 or fewer', () => {
+    setup({ availableZones: [...FORWARD, ...reverseZones(5)] });
+
+    const list = openSelect(/select zone/i);
+    // Every reverse zone is a directly selectable option...
+    expect(list.getByText('0.0.192.in-addr.arpa')).toBeInTheDocument();
+    // ...and there is no "Reverse zones" sub-selection entry.
+    expect(list.queryByText(/^reverse zones/i)).not.toBeInTheDocument();
+  });
+
+  it('collapses reverse zones behind a sub-selection entry when there are more than 5', () => {
+    setup({ availableZones: [...FORWARD, ...reverseZones(6)] });
+
+    const list = openSelect(/select zone/i);
+    // Forward zones stay inline.
+    expect(list.getByText('example.com')).toBeInTheDocument();
+    // The reverse zones are no longer directly in the main list...
+    expect(list.queryByText('0.0.192.in-addr.arpa')).not.toBeInTheDocument();
+    // ...they live behind a single sub-selection entry.
+    expect(list.getByText(/^reverse zones/i)).toBeInTheDocument();
+  });
+
+  it('reveals a second dropdown and selects a reverse zone through it', () => {
+    const { selectZone } = setup({ availableZones: [...FORWARD, ...reverseZones(6)] });
+
+    // Choose the sub-selection entry in the main dropdown.
+    fireEvent.click(openSelect(/select zone/i).getByText(/^reverse zones/i));
+    // Picking the entry alone must not commit a zone.
+    expect(selectZone).not.toHaveBeenCalled();
+
+    // A dedicated reverse-zone dropdown appears; pick a zone from it.
+    fireEvent.click(openSelect(/reverse zone/i).getByText('3.0.192.in-addr.arpa'));
+    expect(selectZone).toHaveBeenCalledWith('3.0.192.in-addr.arpa');
+  });
+
+  it('shows the sub-dropdown pre-selected when a reverse zone is already selected', () => {
+    setup({
+      availableZones: [...FORWARD, ...reverseZones(6)],
+      selectedZone: '2.0.192.in-addr.arpa'
+    });
+
+    // The reverse-zone dropdown is rendered and reflects the current selection.
+    const reverseTrigger = screen.getByRole('combobox', { name: /reverse zone/i });
+    expect(within(reverseTrigger).getByText('2.0.192.in-addr.arpa')).toBeInTheDocument();
+    // The main dropdown shows the sub-selection entry rather than a zone.
+    expect(screen.getByRole('combobox', { name: /select zone/i })).toHaveTextContent(/reverse zones/i);
+  });
+});

--- a/src/services/dnsRecordFormatter.ts
+++ b/src/services/dnsRecordFormatter.ts
@@ -2,6 +2,12 @@
 import { DNSRecord } from '../types/dns';
 import { DNSValidationService } from './dnsValidationService';
 
+// A reverse-DNS zone lives under in-addr.arpa (IPv4) or ip6.arpa (IPv6). Accepts
+// names with or without a trailing dot.
+export function isReverseZone(zone: string): boolean {
+  return /\.(in-addr|ip6)\.arpa\.?$/i.test(zone);
+}
+
 // We can't directly use dns-packet in the frontend due to Node.js dependencies,
 // but we can follow its formatting rules
 export class DNSRecordFormatter {


### PR DESCRIPTION
## Summary

In the **TSIG Key Selection** panel, when the visible zone list contains **more than 5 reverse zones** (`.in-addr.arpa` / `.ip6.arpa`), they're collapsed behind a single `Reverse zones (N)…` entry in the main **Select Zone** dropdown. Choosing it reveals a dedicated **Reverse Zone** dropdown listing only the reverse zones; picking one selects it as before. This keeps forward zones easy to find when many reverse zones are present.

- At **≤5 reverse zones**, behavior is unchanged (all zones inline).
- A persisted reverse-zone selection re-opens the sub-dropdown pre-selected on load.
- New exported `isReverseZone()` helper reuses the existing arpa regex.
- Added `InputLabel`/`labelId` associations on the key/zone/reverse-zone selects (accessibility + testability).

## Tests

New `KeySelector.test.tsx` (4 tests, written test-first): inline at ≤5, sentinel + hidden reverse list at >5, drill-through selection calls `selectZone`, and pre-selected sub-dropdown for a persisted reverse zone. Full frontend suite 240/240, `tsc --noEmit` clean.

## Release

Minor bump to **3.1.0** (backward-compatible feature); see `CHANGELOG.md`.