### PR TITLE
Personal API tokens + snapshot disk-usage guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,5 +31,10 @@ ZONE_RECORDS_WARNING_THRESHOLD=5000
 # Maximum dig output size in bytes (50MB default)
 MAX_DIG_OUTPUT_SIZE=52428800
 
+# Snapshot (backup) storage budget
+# Total on-disk budget for all server-side snapshots (data/backups). Once a new
+# snapshot would exceed this, the oldest snapshots are evicted first. Default 512.
+BACKUP_MAX_TOTAL_SIZE_MB=512
+
 # Temporary Directory for nsupdate files
 TEMP_DIR=/tmp/snap-dns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2026-07-21
+
+### Added
+
+- **Personal API tokens for programmatic access.** Users can mint bearer tokens
+  (`sdns_<40 hex>`) from the new "API Tokens" tab in Settings to drive DNS
+  operations from scripts/CI. Only a SHA-256 hash is stored server-side
+  (`data/api-tokens.json`); the raw token is shown exactly once and never logged.
+  A token authenticates as its owner with the owner's **live** privileges
+  (role/zone/key allowlists re-read per request, so revocations apply
+  immediately). Sessions remain the primary auth path and always take precedence.
+  Token create/list/revoke are session-only (a token can never manage tokens),
+  require the current password, are rate-limited per principal, and audited.
+  Tokens can be given an optional expiry (capped at 365 days).
+
+  Note: because zone operations require an explicit `keyId` (see 3.2.0),
+  programmatic callers must include the `keyId` (query param on `GET`, body field
+  on writes) just as the UI does.
+
+### Fixed
+
+- **Snapshot storage is now bounded.** Server-side snapshots could grow without
+  limit and fill the disk. A global size budget (`BACKUP_MAX_TOTAL_SIZE_MB`,
+  default 512 MB) now evicts the globally-oldest snapshots once a new one would
+  exceed it, and a snapshot larger than the whole budget is rejected. Snapshot
+  creation is also gated by the same deny-by-default zone-access check as the
+  zone routes, closing a path where an editor could spawn unbounded per-zone
+  files for zones they cannot access.
+
 ## [3.2.0] - 2026-07-21
 
 ### Fixed

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "main": "dist/server.js",
   "scripts": {
     "start": "node dist/server.js",

--- a/backend/src/__tests__/integration/backupZoneAccess.integration.test.ts
+++ b/backend/src/__tests__/integration/backupZoneAccess.integration.test.ts
@@ -1,0 +1,51 @@
+// backend/src/__tests__/integration/backupZoneAccess.integration.test.ts
+// Creating a snapshot writes a per-zone file on disk. Without a zone-access check
+// an authenticated editor could POST to arbitrarily many distinct :zone values,
+// spawning unbounded files. The create route must enforce the same deny-by-default
+// zone gate as the zone routes, so a snapshot can only be created for a zone the
+// user may access.
+import type { Express } from 'express';
+import { buildTestApp, seedUser, loginAgent } from './testApp';
+import { UserRole } from '../../types/auth';
+
+const body = {
+  records: [{ name: 'www.example.com', type: 'A', value: '192.0.2.10', ttl: 3600, class: 'IN' }],
+  server: '192.0.2.53',
+  type: 'manual',
+  description: 'test',
+};
+
+describe('Snapshot creation zone-access gate (HTTP)', () => {
+  let app: Express;
+
+  beforeAll(async () => {
+    app = buildTestApp();
+    await seedUser({
+      username: 'editorz',
+      password: 'editor-pass-123',
+      role: UserRole.EDITOR,
+      allowedZones: ['example.com'],
+    });
+    await seedUser({ username: 'adminz', password: 'admin-pass-123', role: UserRole.ADMIN });
+  });
+
+  it('allows creating a snapshot for a zone the editor may access', async () => {
+    const { agent } = await loginAgent(app, 'editorz', 'editor-pass-123');
+    const res = await agent.post('/api/backups/zone/example.com').send(body);
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('denies creating a snapshot for a zone the editor may not access', async () => {
+    const { agent } = await loginAgent(app, 'editorz', 'editor-pass-123');
+    const res = await agent.post('/api/backups/zone/other.org').send(body);
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('PERMISSION_DENIED');
+  });
+
+  it('lets an admin create a snapshot for any zone', async () => {
+    const { agent } = await loginAgent(app, 'adminz', 'admin-pass-123');
+    const res = await agent.post('/api/backups/zone/anything.example').send(body);
+    expect(res.status).toBe(201);
+  });
+});

--- a/backend/src/__tests__/integration/tokenAuth.integration.test.ts
+++ b/backend/src/__tests__/integration/tokenAuth.integration.test.ts
@@ -11,41 +11,42 @@ import { dnsService } from '../../services/dnsService';
 import { tsigKeyService } from '../../services/tsigKeyService';
 import request from 'supertest';
 
-const fakeKey = {
-  id: 'key-1',
-  name: 'test-key',
-  server: '192.0.2.53',
-  keyName: 'test-key.',
-  keyValue: 'plaintext-secret',
-  algorithm: 'hmac-sha256',
-  zones: ['example.com'],
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  createdBy: 'someone',
-};
-
 describe('API token auth (HTTP)', () => {
   let app: Express;
+  // A real key serving example.com; zone operations now require an explicit
+  // keyId that is resolved (getKey) and authorized against the caller's
+  // allowlist, so the token owners are granted this key below.
+  let zoneKeyId: string;
 
   beforeAll(async () => {
     app = buildTestApp();
+
+    const key = await tsigKeyService.createKey('seed', {
+      name: 'tok-key', server: '192.0.2.53', keyName: 'tok-key.',
+      keyValue: 'c25hcC1kbnMtdGVzdC1rZXk=', algorithm: 'hmac-sha256', zones: ['example.com'],
+    });
+    zoneKeyId = key.id;
+
     await seedUser({
       username: 'tokedit',
       password: 'editor-pass-123',
       role: UserRole.EDITOR,
       allowedZones: ['example.com'],
+      allowedKeyIds: [zoneKeyId],
     });
     await seedUser({
       username: 'otheruser',
       password: 'other-pass-123',
       role: UserRole.EDITOR,
       allowedZones: ['example.com'],
+      allowedKeyIds: [zoneKeyId],
     });
     await seedUser({
       username: 'tokviewer',
       password: 'viewer-pass-123',
       role: UserRole.VIEWER,
       allowedZones: ['example.com'],
+      allowedKeyIds: [zoneKeyId],
     });
     await seedUser({
       username: 'mustchange',
@@ -76,20 +77,20 @@ describe('API token auth (HTTP)', () => {
   });
 
   it('authenticates a bearer request with the owner\'s RBAC', async () => {
-    jest.spyOn(tsigKeyService, 'getKeyForZone').mockResolvedValue(fakeKey);
     jest.spyOn(dnsService, 'fetchZoneRecords').mockResolvedValue([] as never);
 
     const { raw } = await mintToken();
 
-    // Owner has example.com → 200.
+    // Owner has example.com + the key → 200. keyId identifies the view.
     const ok = await request(app)
-      .get('/api/zones/example.com')
+      .get('/api/zones/example.com?keyId=' + zoneKeyId)
       .set('Authorization', 'Bearer ' + raw);
     expect(ok.status).toBe(200);
 
-    // A zone not in the owner's allowedZones → 403 PERMISSION_DENIED.
+    // A zone not in the owner's allowedZones → 403 PERMISSION_DENIED (the zone
+    // gate rejects before key resolution).
     const denied = await request(app)
-      .get('/api/zones/notmine.com')
+      .get('/api/zones/notmine.com?keyId=' + zoneKeyId)
       .set('Authorization', 'Bearer ' + raw);
     expect(denied.status).toBe(403);
     expect(denied.body.code).toBe('PERMISSION_DENIED');
@@ -216,14 +217,13 @@ describe('API token auth (HTTP)', () => {
   });
 
   it("lets an editor's token perform a write (200)", async () => {
-    jest.spyOn(tsigKeyService, 'getKeyForZone').mockResolvedValue(fakeKey);
     const addSpy = jest.spyOn(dnsService, 'addRecord').mockResolvedValue({ success: true } as never);
 
     const { raw } = await mintToken();
     const res = await request(app)
       .post('/api/zones/example.com/records')
       .set('Authorization', 'Bearer ' + raw)
-      .send({ record: { name: 'www.example.com', type: 'A', value: '192.0.2.10', ttl: 3600, class: 'IN' } });
+      .send({ keyId: zoneKeyId, record: { name: 'www.example.com', type: 'A', value: '192.0.2.10', ttl: 3600, class: 'IN' } });
 
     expect(res.status).toBe(200);
     expect(addSpy).toHaveBeenCalledTimes(1);

--- a/backend/src/__tests__/integration/tokenAuth.integration.test.ts
+++ b/backend/src/__tests__/integration/tokenAuth.integration.test.ts
@@ -1,0 +1,249 @@
+// backend/src/__tests__/integration/tokenAuth.integration.test.ts
+// HTTP-level personal API token flow. Tokens are minted/revoked over a session
+// only (a bearer token can never manage tokens), but authenticate any other
+// requireAuth route as the owning user with the owner's live RBAC. The DNS exec
+// layer and the zone's TSIG key lookup are stubbed so these stay pure
+// route/auth tests with no real BIND.
+import type { Express } from 'express';
+import { buildTestApp, seedUser, loginAgent } from './testApp';
+import { UserRole } from '../../types/auth';
+import { dnsService } from '../../services/dnsService';
+import { tsigKeyService } from '../../services/tsigKeyService';
+import request from 'supertest';
+
+const fakeKey = {
+  id: 'key-1',
+  name: 'test-key',
+  server: '192.0.2.53',
+  keyName: 'test-key.',
+  keyValue: 'plaintext-secret',
+  algorithm: 'hmac-sha256',
+  zones: ['example.com'],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  createdBy: 'someone',
+};
+
+describe('API token auth (HTTP)', () => {
+  let app: Express;
+
+  beforeAll(async () => {
+    app = buildTestApp();
+    await seedUser({
+      username: 'tokedit',
+      password: 'editor-pass-123',
+      role: UserRole.EDITOR,
+      allowedZones: ['example.com'],
+    });
+    await seedUser({
+      username: 'otheruser',
+      password: 'other-pass-123',
+      role: UserRole.EDITOR,
+      allowedZones: ['example.com'],
+    });
+    await seedUser({
+      username: 'tokviewer',
+      password: 'viewer-pass-123',
+      role: UserRole.VIEWER,
+      allowedZones: ['example.com'],
+    });
+    await seedUser({
+      username: 'mustchange',
+      password: 'change-pass-123',
+      role: UserRole.EDITOR,
+      allowedZones: ['example.com'],
+      mustChangePassword: true,
+    });
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  /** Session-login the editor and mint a token; return the raw token + its id. */
+  async function mintToken(name = 'ci', body: Record<string, unknown> = {}): Promise<{ raw: string; id: string; res: request.Response }> {
+    const { agent } = await loginAgent(app, 'tokedit', 'editor-pass-123');
+    const res = await agent.post('/api/tokens').send({ name, ...body });
+    return { raw: res.body.token, id: res.body.id, res };
+  }
+
+  it('mints a token over a session with the expected shape', async () => {
+    const { res, raw } = await mintToken();
+    expect(res.status).toBe(201);
+    expect(raw).toMatch(/^sdns_[0-9a-f]{40}$/);
+    expect(res.body.prefix).toBe(raw.slice(0, 12));
+    expect(typeof res.body.id).toBe('string');
+    expect(res.body.expiresAt).toBeNull();
+    expect(res.body.name).toBe('ci');
+  });
+
+  it('authenticates a bearer request with the owner\'s RBAC', async () => {
+    jest.spyOn(tsigKeyService, 'getKeyForZone').mockResolvedValue(fakeKey);
+    jest.spyOn(dnsService, 'fetchZoneRecords').mockResolvedValue([] as never);
+
+    const { raw } = await mintToken();
+
+    // Owner has example.com → 200.
+    const ok = await request(app)
+      .get('/api/zones/example.com')
+      .set('Authorization', 'Bearer ' + raw);
+    expect(ok.status).toBe(200);
+
+    // A zone not in the owner's allowedZones → 403 PERMISSION_DENIED.
+    const denied = await request(app)
+      .get('/api/zones/notmine.com')
+      .set('Authorization', 'Bearer ' + raw);
+    expect(denied.status).toBe(403);
+    expect(denied.body.code).toBe('PERMISSION_DENIED');
+  });
+
+  it('rejects an unknown bearer token with 401 INVALID_TOKEN', async () => {
+    const res = await request(app)
+      .get('/api/zones/example.com')
+      .set('Authorization', 'Bearer sdns_' + '0'.repeat(40));
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('INVALID_TOKEN');
+  });
+
+  it('rejects a revoked token with 401 INVALID_TOKEN', async () => {
+    const { raw, id } = await mintToken();
+
+    const { agent } = await loginAgent(app, 'tokedit', 'editor-pass-123');
+    const del = await agent.delete('/api/tokens/' + id);
+    expect(del.status).toBe(200);
+    expect(del.body.success).toBe(true);
+
+    const res = await request(app)
+      .get('/api/zones/example.com')
+      .set('Authorization', 'Bearer ' + raw);
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('INVALID_TOKEN');
+  });
+
+  it('rejects an expired token with 401 INVALID_TOKEN', async () => {
+    const { raw } = await mintToken('short', { expiresInDays: 1 });
+
+    jest.spyOn(Date, 'now').mockReturnValue(Date.now() + 2 * 86_400_000);
+
+    const res = await request(app)
+      .get('/api/zones/example.com')
+      .set('Authorization', 'Bearer ' + raw);
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('INVALID_TOKEN');
+  });
+
+  it('forbids a bearer token from minting or revoking tokens (SESSION_REQUIRED)', async () => {
+    const { raw, id } = await mintToken();
+
+    const create = await request(app)
+      .post('/api/tokens')
+      .set('Authorization', 'Bearer ' + raw)
+      .send({ name: 'x' });
+    expect(create.status).toBe(401);
+    expect(create.body.code).toBe('SESSION_REQUIRED');
+
+    const del = await request(app)
+      .delete('/api/tokens/' + id)
+      .set('Authorization', 'Bearer ' + raw);
+    expect(del.status).toBe(401);
+    expect(del.body.code).toBe('SESSION_REQUIRED');
+  });
+
+  it('lists only the caller\'s own tokens, metadata only', async () => {
+    await mintToken('mine');
+
+    const { agent } = await loginAgent(app, 'tokedit', 'editor-pass-123');
+    const res = await agent.get('/api/tokens');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.tokens)).toBe(true);
+    expect(res.body.tokens.length).toBeGreaterThan(0);
+    for (const t of res.body.tokens) {
+      expect(t.tokenHash).toBeUndefined();
+      expect(t.userId).toBeUndefined();
+      expect(t.token).toBeUndefined();
+    }
+
+    // A different user sees none of the editor's tokens.
+    const editorIds = new Set(res.body.tokens.map((t: any) => t.id));
+    const { agent: other } = await loginAgent(app, 'otheruser', 'other-pass-123');
+    const otherRes = await other.get('/api/tokens');
+    expect(otherRes.status).toBe(200);
+    for (const t of otherRes.body.tokens) {
+      expect(editorIds.has(t.id)).toBe(false);
+    }
+  });
+
+  it('rejects a token create with a missing name (400 VALIDATION_ERROR)', async () => {
+    const { agent } = await loginAgent(app, 'tokedit', 'editor-pass-123');
+    const res = await agent.post('/api/tokens').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('rejects token routes with no auth at all (401 NOT_AUTHENTICATED / SESSION_REQUIRED)', async () => {
+    const list = await request(app).get('/api/tokens');
+    expect(list.status).toBe(401);
+    expect(list.body.code).toBe('NOT_AUTHENTICATED');
+  });
+
+  // --- QA-driven hardening --------------------------------------------------
+
+  it('blocks minting a token while a password change is forced (403 PASSWORD_CHANGE_REQUIRED)', async () => {
+    // Otherwise a not-yet-rotated account (e.g. the default admin) could mint a
+    // long-lived credential that survives the forced rotation.
+    const { agent } = await loginAgent(app, 'mustchange', 'change-pass-123');
+    const res = await agent.post('/api/tokens').send({ name: 'sneaky' });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('PASSWORD_CHANGE_REQUIRED');
+  });
+
+  it('caps requested token lifetime (rejects an implausibly long expiry)', async () => {
+    const { agent } = await loginAgent(app, 'tokedit', 'editor-pass-123');
+    const res = await agent.post('/api/tokens').send({ name: 'toolong', expiresInDays: 3650 });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('VALIDATION_ERROR');
+  });
+
+  it("blocks a viewer's token from a write (403 READ_ONLY)", async () => {
+    const { agent } = await loginAgent(app, 'tokviewer', 'viewer-pass-123');
+    const mint = await agent.post('/api/tokens').send({ name: 'ro' });
+    expect(mint.status).toBe(201);
+
+    const res = await request(app)
+      .post('/api/zones/example.com/records')
+      .set('Authorization', 'Bearer ' + mint.body.token)
+      .send({ record: { name: 'www.example.com', type: 'A', value: '192.0.2.10', ttl: 3600, class: 'IN' } });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('READ_ONLY');
+  });
+
+  it("lets an editor's token perform a write (200)", async () => {
+    jest.spyOn(tsigKeyService, 'getKeyForZone').mockResolvedValue(fakeKey);
+    const addSpy = jest.spyOn(dnsService, 'addRecord').mockResolvedValue({ success: true } as never);
+
+    const { raw } = await mintToken();
+    const res = await request(app)
+      .post('/api/zones/example.com/records')
+      .set('Authorization', 'Bearer ' + raw)
+      .send({ record: { name: 'www.example.com', type: 'A', value: '192.0.2.10', ttl: 3600, class: 'IN' } });
+
+    expect(res.status).toBe(200);
+    expect(addSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a non-sdns bearer header and falls through to 401 NOT_AUTHENTICATED', async () => {
+    const res = await request(app)
+      .get('/api/zones/example.com')
+      .set('Authorization', 'Bearer garbage');
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('NOT_AUTHENTICATED');
+  });
+
+  it('lets a session take precedence over a bearer header on the same request', async () => {
+    const { raw } = await mintToken();
+    // otheruser session cookie + tokedit bearer header: session identity wins,
+    // so the token list is otheruser's (which never contains tokedit's token).
+    const { agent } = await loginAgent(app, 'otheruser', 'other-pass-123');
+    const res = await agent.get('/api/tokens').set('Authorization', 'Bearer ' + raw);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.tokens)).toBe(true);
+  });
+});

--- a/backend/src/config/backups.ts
+++ b/backend/src/config/backups.ts
@@ -1,0 +1,52 @@
+// backend/src/config/backups.ts
+// Single place that resolves server-side snapshot (backup) storage settings from
+// the environment.
+//
+// Snapshots (data/backups/<zone>.json) embed a full copy of a zone's records and
+// would otherwise grow without bound across zones, eventually filling the disk on
+// a long-running deployment. These knobs drive a global size budget in
+// backupService (oldest snapshots are evicted first once the budget is exceeded):
+//   - BACKUP_MAX_TOTAL_SIZE_MB  total budget for the whole backups directory
+//                               (default 512 MB)
+//   - BACKUP_DIR                backups directory (default data/backups under cwd)
+
+import path from 'path';
+
+export interface BackupConfig {
+  /** Directory holding the per-zone backup files. */
+  dir: string;
+  /** Total on-disk budget for all backups, in bytes. */
+  maxTotalBytes: number;
+}
+
+const DEFAULT_MAX_TOTAL_MB = 512;
+
+/**
+ * Parse a strictly-positive integer env var, falling back to `fallback` for
+ * unset, empty, non-numeric, or non-positive values.
+ */
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = parseInt(value.trim(), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+/**
+ * Resolve the backup storage configuration from the given environment (defaults
+ * to process.env). Resolved in one place so both the service and tests agree on
+ * the knobs and their defaults.
+ */
+export function resolveBackupConfig(env: NodeJS.ProcessEnv = process.env): BackupConfig {
+  const maxTotalMb = parsePositiveInt(env.BACKUP_MAX_TOTAL_SIZE_MB, DEFAULT_MAX_TOTAL_MB);
+  const dir = env.BACKUP_DIR || path.join(process.cwd(), 'data', 'backups');
+
+  return {
+    dir,
+    maxTotalBytes: maxTotalMb * 1024 * 1024,
+  };
+}

--- a/backend/src/helpers/zoneAccess.ts
+++ b/backend/src/helpers/zoneAccess.ts
@@ -1,0 +1,18 @@
+// backend/src/helpers/zoneAccess.ts
+// Shared zone-access check used by both the zone routes and the backup routes.
+//
+// Privileges are read from the DB on each request so changes take effect without
+// a re-login. Deny-by-default: a non-admin with no allowedZones may access no
+// zone (consistent with allowedKeyIds). Admins bypass the gate entirely.
+
+import { userService } from '../services/userService';
+
+export async function checkZoneAccess(
+  user: { role: string; userId: string },
+  zone: string
+): Promise<boolean> {
+  if (user.role === 'admin') return true;
+  const dbUser = await userService.getUserById(user.userId);
+  if (!dbUser) return false;
+  return dbUser.allowedZones.some(z => z.toLowerCase() === zone.toLowerCase());
+}

--- a/backend/src/middleware/__tests__/rateLimiter.principalKey.test.ts
+++ b/backend/src/middleware/__tests__/rateLimiter.principalKey.test.ts
@@ -1,0 +1,35 @@
+// backend/src/middleware/__tests__/rateLimiter.principalKey.test.ts
+// The rate-limit key must identify the principal so bearer-token traffic is
+// throttled per token (not lumped into a shared per-IP bucket) and sessions are
+// throttled per user.
+import crypto from 'crypto';
+import { principalKey } from '../rateLimiter';
+
+// Minimal request shape; principalKey only reads session/headers/ip.
+const req = (over: Record<string, unknown>): any => ({ headers: {}, ...over });
+
+describe('principalKey', () => {
+  it('keys an authenticated session by user id', () => {
+    expect(principalKey(req({ session: { userId: 'u1' }, ip: '10.0.0.1' }))).toBe('user:u1');
+  });
+
+  it('keys a bearer API token by a stable hash fingerprint (not the raw token)', () => {
+    const raw = 'sdns_' + 'a'.repeat(40);
+    const expected = 'token:' + crypto.createHash('sha256').update(raw).digest('hex').slice(0, 16);
+    const key = principalKey(req({ headers: { authorization: 'Bearer ' + raw }, ip: '10.0.0.1' }));
+    expect(key).toBe(expected);
+    expect(key).not.toContain(raw); // never leak the raw token into the key
+  });
+
+  it('gives two different tokens different buckets', () => {
+    const a = principalKey(req({ headers: { authorization: 'Bearer sdns_' + 'a'.repeat(40) } }));
+    const b = principalKey(req({ headers: { authorization: 'Bearer sdns_' + 'b'.repeat(40) } }));
+    expect(a).not.toBe(b);
+  });
+
+  it('falls back to client IP when unauthenticated', () => {
+    expect(principalKey(req({ ip: '203.0.113.5' }))).toBe('203.0.113.5');
+    // A non-sdns bearer header is not a token principal → still IP.
+    expect(principalKey(req({ headers: { authorization: 'Bearer garbage' }, ip: '203.0.113.5' }))).toBe('203.0.113.5');
+  });
+});

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -2,6 +2,8 @@
 import { Request, Response, NextFunction } from 'express';
 import { AuthenticatedRequest, UserRole } from '../types/auth';
 import { userService } from '../services/userService';
+import { apiTokenService } from '../services/apiTokenService';
+import { auditService, AuditEventType } from '../services/auditService';
 
 /**
  * Middleware to check if user is authenticated.
@@ -16,48 +18,116 @@ import { userService } from '../services/userService';
 export async function requireAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
   const authReq = req as AuthenticatedRequest;
 
+  // Session auth stays PRIMARY: when a session is present it fully decides the
+  // request and the bearer fallback below is never consulted.
+  if (req.session && req.session.userId) {
+    try {
+      // Re-load current privileges from the user store (in-memory, cheap).
+      const dbUser = await userService.getUserById(req.session.userId);
+
+      if (!dbUser) {
+        // User was deleted mid-session: destroy the session so it stops working
+        // immediately, then reject.
+        req.session.destroy(() => {
+          res.status(401).json({
+            success: false,
+            error: 'Authentication required',
+            code: 'NOT_AUTHENTICATED'
+          });
+        });
+        return;
+      }
+
+      // Identity comes from the session; privileges (and the forced
+      // password-change flag) come from the database so a cleared flag takes
+      // effect on the very next request.
+      authReq.user = {
+        userId: req.session.userId,
+        username: req.session.username || dbUser.username,
+        role: dbUser.role,
+        allowedKeyIds: dbUser.allowedKeyIds,
+        allowedZones: dbUser.allowedZones || [],
+        mustChangePassword: dbUser.mustChangePassword ?? false,
+      };
+
+      next();
+      return;
+    } catch (err) {
+      next(err);
+      return;
+    }
+  }
+
+  // Bearer fallback: a personal API token authenticates as its OWNER with the
+  // owner's CURRENT privileges (loaded live from userService, so revocations and
+  // role changes take effect immediately). The raw token / hash is never logged
+  // — only the 12-char prefix appears in audit details.
+  const header = req.headers?.authorization;
+  if (header && header.startsWith('Bearer sdns_')) {
+    const raw = header.slice(7).trim();
+    try {
+      const result = await apiTokenService.verifyToken(raw);
+      if (result.status !== 'valid') {
+        await auditService.log(AuditEventType.TOKEN_AUTH_FAILED, {
+          success: false,
+          ipAddress: req.ip,
+          details: { reason: result.status, prefix: raw.slice(0, 12) },
+        }).catch(() => { /* audit is best-effort; never block the 401 */ });
+        res.status(401).json({ success: false, error: 'Invalid API token', code: 'INVALID_TOKEN' });
+        return;
+      }
+
+      const dbUser = await userService.getUserById(result.token.userId);
+      if (!dbUser) {
+        await auditService.log(AuditEventType.TOKEN_AUTH_FAILED, {
+          success: false,
+          ipAddress: req.ip,
+          details: { reason: 'user_missing', prefix: raw.slice(0, 12) },
+        }).catch(() => { /* audit is best-effort; never block the 401 */ });
+        res.status(401).json({ success: false, error: 'Invalid API token', code: 'INVALID_TOKEN' });
+        return;
+      }
+
+      authReq.user = {
+        userId: dbUser.id,
+        username: dbUser.username,
+        role: dbUser.role,
+        allowedKeyIds: dbUser.allowedKeyIds,
+        allowedZones: dbUser.allowedZones || [],
+        mustChangePassword: dbUser.mustChangePassword ?? false,
+      };
+
+      next();
+      return;
+    } catch (err) {
+      next(err);
+      return;
+    }
+  }
+
+  res.status(401).json({
+    success: false,
+    error: 'Authentication required',
+    code: 'NOT_AUTHENTICATED'
+  });
+}
+
+/**
+ * Middleware that requires an interactive session (never a bearer token). Used
+ * to guard token creation/revocation so an API token can never mint or manage
+ * tokens. Must run AFTER requireAuth in the chain; it checks the session
+ * directly rather than req.user so a bearer-authenticated request is rejected.
+ */
+export function requireSessionAuth(req: Request, res: Response, next: NextFunction): void {
   if (!req.session || !req.session.userId) {
     res.status(401).json({
       success: false,
-      error: 'Authentication required',
-      code: 'NOT_AUTHENTICATED'
+      error: 'This action requires an interactive session, not an API token',
+      code: 'SESSION_REQUIRED'
     });
     return;
   }
-
-  try {
-    // Re-load current privileges from the user store (in-memory, cheap).
-    const dbUser = await userService.getUserById(req.session.userId);
-
-    if (!dbUser) {
-      // User was deleted mid-session: destroy the session so it stops working
-      // immediately, then reject.
-      req.session.destroy(() => {
-        res.status(401).json({
-          success: false,
-          error: 'Authentication required',
-          code: 'NOT_AUTHENTICATED'
-        });
-      });
-      return;
-    }
-
-    // Identity comes from the session; privileges (and the forced
-    // password-change flag) come from the database so a cleared flag takes
-    // effect on the very next request.
-    authReq.user = {
-      userId: req.session.userId,
-      username: req.session.username || dbUser.username,
-      role: dbUser.role,
-      allowedKeyIds: dbUser.allowedKeyIds,
-      allowedZones: dbUser.allowedZones || [],
-      mustChangePassword: dbUser.mustChangePassword ?? false,
-    };
-
-    next();
-  } catch (err) {
-    next(err);
-  }
+  next();
 }
 
 /**

--- a/backend/src/middleware/rateLimiter.ts
+++ b/backend/src/middleware/rateLimiter.ts
@@ -2,12 +2,33 @@
 // Rate limiting middleware for DNS operations and API endpoints
 
 import { rateLimit } from 'express-rate-limit';
+import type { Request } from 'express';
+import crypto from 'crypto';
 import { isRateLimitEnabled } from '../config/securityToggles';
 
 // Rate limiting is ON by default (secure) and only skipped when explicitly
 // disabled via RATE_LIMIT_ENABLED=false -- not based on NODE_ENV. See
 // config/securityToggles.ts for the rationale.
 const rateLimitDisabled = !isRateLimitEnabled();
+
+/**
+ * Per-principal rate-limit key. Limiters run BEFORE requireAuth, so this inspects
+ * the session/header directly: prefer the authenticated user, then a stable
+ * fingerprint of a bearer API token (so token traffic is throttled per token
+ * rather than lumped into a shared per-IP bucket, which would let co-located
+ * token clients starve each other), then finally the client IP.
+ */
+export function principalKey(req: Request): string {
+  if (req.session?.userId) {
+    return `user:${req.session.userId}`;
+  }
+  const header = req.headers?.authorization;
+  if (header && header.startsWith('Bearer sdns_')) {
+    const raw = header.slice(7).trim();
+    return `token:${crypto.createHash('sha256').update(raw).digest('hex').slice(0, 16)}`;
+  }
+  return req.ip || 'unknown';
+}
 
 /**
  * Rate limiter for DNS zone queries (GET operations)
@@ -26,7 +47,8 @@ export const dnsQueryLimiter = rateLimit({
   // Skip only when rate limiting is explicitly disabled (default: enabled)
   skip: (_req) => {
     return rateLimitDisabled;
-  }
+  },
+  keyGenerator: principalKey
 });
 
 /**
@@ -47,15 +69,7 @@ export const dnsModifyLimiter = rateLimit({
   skip: (_req) => {
     return rateLimitDisabled;
   },
-  // Use user ID as key for authenticated requests
-  keyGenerator: (req) => {
-    // If authenticated, use user ID for per-user limits
-    if (req.session?.userId) {
-      return `user:${req.session.userId}`;
-    }
-    // Fall back to IP address
-    return req.ip || 'unknown';
-  }
+  keyGenerator: principalKey
 });
 
 /**
@@ -76,12 +90,28 @@ export const keyManagementLimiter = rateLimit({
   skip: (_req) => {
     return rateLimitDisabled;
   },
-  keyGenerator: (req) => {
-    if (req.session?.userId) {
-      return `user:${req.session.userId}`;
-    }
-    return req.ip || 'unknown';
-  }
+  keyGenerator: principalKey
+});
+
+/**
+ * Rate limiter for personal API token operations (create/list/revoke)
+ * Moderate per-user limits; token management is sensitive but low-frequency.
+ */
+export const tokenLimiter = rateLimit({
+  windowMs: 5 * 60 * 1000, // 5 minutes
+  max: 20, // 20 token operations per 5 minutes
+  message: {
+    success: false,
+    error: 'Too many token operations, please slow down',
+    code: 'RATE_LIMIT_EXCEEDED'
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+  // Skip only when rate limiting is explicitly disabled (default: enabled)
+  skip: (_req) => {
+    return rateLimitDisabled;
+  },
+  keyGenerator: principalKey
 });
 
 /**
@@ -102,12 +132,7 @@ export const webhookLimiter = rateLimit({
   skip: (_req) => {
     return rateLimitDisabled;
   },
-  keyGenerator: (req) => {
-    if (req.session?.userId) {
-      return `user:${req.session.userId}`;
-    }
-    return req.ip || 'unknown';
-  }
+  keyGenerator: principalKey
 });
 
 /**
@@ -127,5 +152,6 @@ export const generalApiLimiter = rateLimit({
   // Skip only when rate limiting is explicitly disabled (default: enabled)
   skip: (_req) => {
     return rateLimitDisabled;
-  }
+  },
+  keyGenerator: principalKey
 });

--- a/backend/src/middleware/validation.ts
+++ b/backend/src/middleware/validation.ts
@@ -123,6 +123,16 @@ export const TSIGKeyUpdateSchema = z.object({
 });
 
 /**
+ * Personal API token schemas
+ */
+export const TokenCreateSchema = z.object({
+  name: z.string().min(1, 'Token name is required').max(100),
+  // Cap explicit lifetimes at one year to match the UI options and avoid
+  // decade-long tokens; omit for a non-expiring token.
+  expiresInDays: z.number().int().min(1).max(365).optional(),
+});
+
+/**
  * Authentication schemas
  */
 export const LoginRequestSchema = z.object({
@@ -192,6 +202,7 @@ export const validateUpdateRecord = validateRequest(UpdateRecordRequestSchema);
 export const validateBatch = validateRequest(BatchRequestSchema);
 export const validateTSIGKeyCreate = validateRequest(TSIGKeyCreateSchema);
 export const validateTSIGKeyUpdate = validateRequest(TSIGKeyUpdateSchema);
+export const validateTokenCreate = validateRequest(TokenCreateSchema);
 export const validateLogin = validateRequest(LoginRequestSchema);
 export const validateUserCreate = validateRequest(UserCreateSchema);
 export const validateChangePassword = validateRequest(ChangePasswordSchema);

--- a/backend/src/routes/backupRoutes.ts
+++ b/backend/src/routes/backupRoutes.ts
@@ -4,6 +4,7 @@ import { requireAuth, requireWriteAccess, requirePasswordCurrent } from '../midd
 import { AuthenticatedRequest } from '../types/auth';
 import { backupService } from '../services/backupService';
 import { auditService, AuditEventType } from '../services/auditService';
+import { checkZoneAccess } from '../helpers/zoneAccess';
 
 const router = Router();
 
@@ -110,6 +111,17 @@ router.post('/zone/:zone', requireAuth, requireWriteAccess, requirePasswordCurre
     const user = authReq.user!;
     const { zone } = req.params;
     const { records, server, keyId, type, description } = req.body;
+
+    // A snapshot writes a per-zone file on disk, so it must be gated by the same
+    // deny-by-default zone check as the zone routes. Without this an editor could
+    // POST to arbitrarily many distinct zones and spawn unbounded files.
+    if (!await checkZoneAccess(user, zone)) {
+      return res.status(403).json({
+        success: false,
+        error: 'Access denied to this zone',
+        code: 'PERMISSION_DENIED',
+      });
+    }
 
     // Validate required fields
     if (!records || !Array.isArray(records)) {

--- a/backend/src/routes/tokenRoutes.ts
+++ b/backend/src/routes/tokenRoutes.ts
@@ -1,0 +1,121 @@
+// backend/src/routes/tokenRoutes.ts
+// Personal API token endpoints.
+//
+// POST and DELETE are SESSION-ONLY (requireSessionAuth) so a bearer token can
+// never mint or manage tokens. GET accepts either a session or a bearer token
+// (read-only metadata of the caller's own tokens). The raw token is returned
+// exactly once by POST and is never logged or persisted in plaintext.
+
+import { Router, Request, Response } from 'express';
+import { requireAuth, requireSessionAuth, requirePasswordCurrent } from '../middleware/auth';
+import { AuthenticatedRequest } from '../types/auth';
+import { apiTokenService } from '../services/apiTokenService';
+import { tokenLimiter } from '../middleware/rateLimiter';
+import { validateTokenCreate } from '../middleware/validation';
+import { auditService, AuditEventType } from '../services/auditService';
+
+const router = Router();
+
+// Apply rate limiting to all token routes
+router.use(tokenLimiter);
+
+/**
+ * POST /api/tokens
+ * Create a personal API token (session only). Returns the raw token ONCE.
+ */
+// requirePasswordCurrent: minting a long-lived credential is a mutation and must
+// obey the same forced-rotation gate as every other mutating route, so a
+// not-yet-rotated account cannot create a token that outlives the rotation.
+router.post('/', requireAuth, requireSessionAuth, requirePasswordCurrent, validateTokenCreate, async (req: Request, res: Response) => {
+  try {
+    const authReq = req as AuthenticatedRequest;
+    const user = authReq.user!;
+    const { name, expiresInDays } = req.body;
+
+    const { raw, record } = await apiTokenService.createToken(user.userId, name, expiresInDays);
+
+    // Audit creation with identifying metadata only — never the raw token/hash.
+    await auditService.log(AuditEventType.TOKEN_CREATED, {
+      userId: user.userId,
+      username: user.username,
+      success: true,
+      details: { tokenId: record.id, name: record.name },
+    });
+
+    res.status(201).json({
+      success: true,
+      token: raw,
+      id: record.id,
+      name: record.name,
+      prefix: record.tokenPrefix,
+      createdAt: record.createdAt,
+      expiresAt: record.expiresAt,
+    });
+  } catch (error: any) {
+    console.error('Create API token error:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to create token',
+      code: 'SERVER_ERROR',
+    });
+  }
+});
+
+/**
+ * GET /api/tokens
+ * List the caller's own, non-revoked tokens (session OR bearer). Metadata only.
+ */
+router.get('/', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const authReq = req as AuthenticatedRequest;
+    const user = authReq.user!;
+
+    const tokens = await apiTokenService.listTokensForUser(user.userId);
+    res.json({ success: true, tokens });
+  } catch (error) {
+    console.error('List API tokens error:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to list tokens',
+      code: 'SERVER_ERROR',
+    });
+  }
+});
+
+/**
+ * DELETE /api/tokens/:id
+ * Revoke one of the caller's own tokens (session only).
+ */
+router.delete('/:id', requireAuth, requireSessionAuth, requirePasswordCurrent, async (req: Request, res: Response) => {
+  try {
+    const authReq = req as AuthenticatedRequest;
+    const user = authReq.user!;
+
+    const ok = await apiTokenService.revokeToken(user.userId, req.params.id);
+    if (!ok) {
+      return res.status(404).json({
+        success: false,
+        error: 'Token not found',
+        code: 'TOKEN_NOT_FOUND',
+      });
+    }
+
+    await auditService.log(AuditEventType.TOKEN_REVOKED, {
+      userId: user.userId,
+      username: user.username,
+      success: true,
+      details: { tokenId: req.params.id },
+    });
+
+    res.json({ success: true, message: 'Token revoked' });
+  } catch (error) {
+    console.error('Revoke API token error:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to revoke token',
+      code: 'SERVER_ERROR',
+    });
+  }
+});
+
+export default router;

--- a/backend/src/routes/zoneRoutes.ts
+++ b/backend/src/routes/zoneRoutes.ts
@@ -5,24 +5,14 @@ import { dnsService } from '../services';
 import { requireAuth, requireWriteAccess, requirePasswordCurrent } from '../middleware/auth';
 import { AuthenticatedRequest } from '../types/auth';
 import { tsigKeyService } from '../services/tsigKeyService';
-import { userService } from '../services/userService';
 import { validationService } from '../services/validationService';
 import { auditService } from '../services/auditService';
 import { dnsQueryLimiter, dnsModifyLimiter } from '../middleware/rateLimiter';
 import { validateAddRecord, validateDeleteRecord, validateUpdateRecord, validateBatch } from '../middleware/validation';
 import { BatchChange } from '../services/dnsService';
+import { checkZoneAccess } from '../helpers/zoneAccess';
 
 const router = Router();
-
-// Fetch allowedZones from DB on each request so changes take effect without re-login.
-// Deny-by-default: a non-admin with no allowedZones may access no zone (consistent
-// with allowedKeyIds). Admins bypass the gate entirely.
-async function checkZoneAccess(user: { role: string; userId: string }, zone: string): Promise<boolean> {
-  if (user.role === 'admin') return true;
-  const dbUser = await userService.getUserById(user.userId);
-  if (!dbUser) return false;
-  return dbUser.allowedZones.some(z => z.toLowerCase() === zone.toLowerCase());
-}
 
 // Add custom error types
 interface DNSError extends Error {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -10,6 +10,7 @@ import { getAllowedOrigins, isOriginAllowed } from './middleware/corsOrigin';
 import { generalApiLimiter } from './middleware/rateLimiter';
 import { userService } from './services/userService';
 import { tsigKeyService } from './services/tsigKeyService';
+import { apiTokenService } from './services/apiTokenService';
 import { backupService } from './services/backupService';
 import { webhookConfigService } from './services/webhookConfigService';
 import { ssoConfigService } from './services/ssoConfigService';
@@ -19,6 +20,7 @@ import zoneRoutes from './routes/zoneRoutes';
 import keyRoutes from './routes/keyRoutes';
 import webhookRoutes from './routes/webhookRoutes';
 import tsigKeyRoutes from './routes/tsigKeyRoutes';
+import tokenRoutes from './routes/tokenRoutes';
 import backupRoutes from './routes/backupRoutes';
 import webhookConfigRoutes from './routes/webhookConfigRoutes';
 import ssoConfigRoutes from './routes/ssoConfigRoutes';
@@ -143,6 +145,7 @@ app.use('/api', generalApiLimiter);
 app.use('/api/auth', authRoutes);
 app.use('/api/auth/sso', ssoAuthRoutes);
 app.use('/api/tsig-keys', tsigKeyRoutes);
+app.use('/api/tokens', tokenRoutes);
 app.use('/api/zones', zoneRoutes);
 app.use('/api/keys', keyRoutes);
 app.use('/api/webhook', webhookRoutes);
@@ -211,6 +214,9 @@ const startServer = async () => {
 
     console.log('Initializing TSIG key service...');
     await tsigKeyService.initialize();
+
+    console.log('Initializing API token service...');
+    await apiTokenService.initialize();
 
     console.log('Initializing backup service...');
     await backupService.initialize();

--- a/backend/src/services/__tests__/apiTokenService.test.ts
+++ b/backend/src/services/__tests__/apiTokenService.test.ts
@@ -1,0 +1,136 @@
+// backend/src/services/__tests__/apiTokenService.test.ts
+// Personal API token lifecycle: only a sha256 hash of the raw token is ever
+// persisted (never the raw string), verification is constant-time and reflects
+// expiry/revocation, lastUsedAt is touched at most once per minute, and list is
+// owner-scoped and metadata-only. Uses a temp file so each test starts clean.
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import crypto from 'crypto';
+import { ApiTokenService } from '../apiTokenService';
+
+const sha256hex = (raw: string): string =>
+  crypto.createHash('sha256').update(raw).digest('hex');
+
+describe('ApiTokenService', () => {
+  let dir: string;
+  let filePath: string;
+  let svc: ApiTokenService;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'snap-tokens-'));
+    filePath = path.join(dir, 'api-tokens.json');
+    svc = new ApiTokenService({ filePath });
+    await svc.initialize();
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('creates a token, hashing it and never persisting the raw value', async () => {
+    const { raw, record } = await svc.createToken('u1', 'ci');
+
+    expect(raw).toMatch(/^sdns_[0-9a-f]{40}$/);
+    expect(record.tokenHash).toBe(sha256hex(raw));
+    expect(record.tokenPrefix).toBe(raw.slice(0, 12));
+    expect(record.userId).toBe('u1');
+    expect(record.lastUsedAt).toBeNull();
+    expect(record.revokedAt).toBeNull();
+
+    const content = await fs.readFile(filePath, 'utf-8');
+    expect(content).not.toContain(raw);
+    expect(content).toContain(record.tokenHash);
+  });
+
+  it('verifies a valid token and rejects an unknown one', async () => {
+    const { raw, record } = await svc.createToken('u1', 'ci');
+
+    const ok = await svc.verifyToken(raw);
+    expect(ok.status).toBe('valid');
+    if (ok.status === 'valid') {
+      expect(ok.token.id).toBe(record.id);
+    }
+
+    const bad = await svc.verifyToken('sdns_' + '0'.repeat(40));
+    expect(bad.status).toBe('not_found');
+  });
+
+  it('reports an expired token as expired', async () => {
+    const { raw } = await svc.createToken('u1', 'ci', 1);
+
+    jest.spyOn(Date, 'now').mockReturnValue(Date.now() + 2 * 86_400_000);
+
+    const res = await svc.verifyToken(raw);
+    expect(res.status).toBe('expired');
+  });
+
+  it('revokes a token (owner-scoped) and reports it revoked', async () => {
+    const { raw, record } = await svc.createToken('u1', 'ci');
+
+    // Wrong owner cannot revoke.
+    expect(await svc.revokeToken('otherUser', record.id)).toBe(false);
+    // Unknown id cannot revoke.
+    expect(await svc.revokeToken('u1', 'missing')).toBe(false);
+
+    expect(await svc.revokeToken('u1', record.id)).toBe(true);
+
+    const res = await svc.verifyToken(raw);
+    expect(res.status).toBe('revoked');
+
+    // Double-revoke is a no-op false.
+    expect(await svc.revokeToken('u1', record.id)).toBe(false);
+
+    const list = await svc.listTokensForUser('u1');
+    expect(list.find(t => t.id === record.id)).toBeUndefined();
+  });
+
+  it('touches lastUsedAt at most once per minute', async () => {
+    // Fake timers so Date.now() and new Date() share one deterministic clock —
+    // the service touches lastUsedAt with new Date() but throttles off Date.now().
+    const base = 1_700_000_000_000;
+    jest.useFakeTimers();
+    jest.setSystemTime(base);
+
+    try {
+      const { raw } = await svc.createToken('u1', 'ci');
+
+      // First verify stamps lastUsedAt.
+      await svc.verifyToken(raw);
+      let list = await svc.listTokensForUser('u1');
+      const firstUsed = list[0].lastUsedAt;
+      expect(firstUsed).not.toBeNull();
+      expect(firstUsed?.getTime()).toBe(base);
+
+      // Immediate second verify (within the window) must NOT advance it.
+      jest.setSystemTime(base + 30_000);
+      await svc.verifyToken(raw);
+      list = await svc.listTokensForUser('u1');
+      expect(list[0].lastUsedAt?.getTime()).toBe(base);
+
+      // Past the 60s throttle window it advances.
+      jest.setSystemTime(base + 61_000);
+      await svc.verifyToken(raw);
+      list = await svc.listTokensForUser('u1');
+      expect(list[0].lastUsedAt?.getTime()).toBe(base + 61_000);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('lists only the caller\'s non-revoked tokens as metadata only', async () => {
+    const a = await svc.createToken('u1', 'a');
+    await svc.createToken('u2', 'b');
+
+    const list = await svc.listTokensForUser('u1');
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe(a.record.id);
+
+    // Metadata only: no secret material, no owner id.
+    const item = list[0] as unknown as Record<string, unknown>;
+    expect(item.tokenHash).toBeUndefined();
+    expect(item.userId).toBeUndefined();
+    expect(item.prefix).toBe(a.record.tokenPrefix);
+  });
+});

--- a/backend/src/services/__tests__/backupService.test.ts
+++ b/backend/src/services/__tests__/backupService.test.ts
@@ -1,0 +1,110 @@
+// backend/src/services/__tests__/backupService.test.ts
+// The snapshot store must never grow past its total size budget: once creating a
+// snapshot would exceed the budget, the oldest snapshots (globally, across all
+// zones) are evicted first. A single snapshot larger than the whole budget is
+// rejected outright. Together these bound on-disk usage regardless of how many
+// zones or snapshots are created.
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { BackupService, DNSRecord } from '../backupService';
+
+// Records sized to a predictable byte count so budgets are easy to reason about.
+const recordsOfSize = (bytes: number): DNSRecord[] => [
+  { name: 'big.example.com', type: 'TXT', value: 'x'.repeat(bytes), ttl: 300, class: 'IN' },
+];
+
+async function dirTotalBytes(dir: string): Promise<number> {
+  const files = await fs.readdir(dir).catch(() => [] as string[]);
+  let total = 0;
+  for (const f of files) {
+    if (!f.endsWith('.json')) continue;
+    total += (await fs.stat(path.join(dir, f))).size;
+  }
+  return total;
+}
+
+describe('BackupService total-size budget', () => {
+  let dir: string;
+  let nowValue: number;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'snap-backups-'));
+    // Monotonic clock so each snapshot gets a strictly newer timestamp/id, making
+    // "oldest evicted first" deterministic.
+    nowValue = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => (nowValue += 1000));
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  const opts = { server: '192.0.2.53', type: 'manual' as const };
+
+  it('keeps total on-disk size within the budget by evicting oldest first', async () => {
+    const svc = new BackupService({ dir, maxTotalBytes: 20 * 1024 });
+
+    const ids: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      const b = await svc.createBackup('example.com', recordsOfSize(4 * 1024), 'u1', opts);
+      ids.push(b.id);
+    }
+
+    // Budget is respected...
+    expect(await dirTotalBytes(dir)).toBeLessThanOrEqual(20 * 1024);
+
+    // ...eviction actually happened (not all 10 survived)...
+    const remaining = await svc.getBackupsForZone('example.com', 'u1', 'admin');
+    expect(remaining.length).toBeLessThan(10);
+
+    // ...the newest snapshot survives and the oldest is gone.
+    const remainingIds = remaining.map(b => b.id);
+    expect(remainingIds).toContain(ids[ids.length - 1]);
+    expect(remainingIds).not.toContain(ids[0]);
+  });
+
+  it('evicts the globally-oldest snapshot even when it lives in another zone', async () => {
+    const svc = new BackupService({ dir, maxTotalBytes: 20 * 1024 });
+
+    // Oldest snapshot is in zone A; newer ones pile into zone B until the budget
+    // forces an eviction.
+    const oldest = await svc.createBackup('a.example.com', recordsOfSize(4 * 1024), 'u1', opts);
+    const newer: string[] = [];
+    for (let i = 0; i < 8; i++) {
+      const b = await svc.createBackup('b.example.com', recordsOfSize(4 * 1024), 'u1', opts);
+      newer.push(b.id);
+    }
+
+    expect(await dirTotalBytes(dir)).toBeLessThanOrEqual(20 * 1024);
+
+    const zoneA = await svc.getBackupsForZone('a.example.com', 'u1', 'admin');
+    expect(zoneA.map(b => b.id)).not.toContain(oldest.id);
+    // The newest zone-B snapshot must still be there.
+    const zoneB = await svc.getBackupsForZone('b.example.com', 'u1', 'admin');
+    expect(zoneB.map(b => b.id)).toContain(newer[newer.length - 1]);
+  });
+
+  it('rejects a single snapshot larger than the entire budget and writes nothing', async () => {
+    const svc = new BackupService({ dir, maxTotalBytes: 2 * 1024 });
+
+    await expect(
+      svc.createBackup('example.com', recordsOfSize(8 * 1024), 'u1', opts)
+    ).rejects.toThrow(/budget/i);
+
+    expect(await dirTotalBytes(dir)).toBeLessThanOrEqual(2 * 1024);
+    const remaining = await svc.getBackupsForZone('example.com', 'u1', 'admin');
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('retains all snapshots when comfortably under budget (newest first)', async () => {
+    const svc = new BackupService({ dir, maxTotalBytes: 10 * 1024 * 1024 });
+
+    const first = await svc.createBackup('example.com', recordsOfSize(100), 'u1', opts);
+    const second = await svc.createBackup('example.com', recordsOfSize(100), 'u1', opts);
+
+    const remaining = await svc.getBackupsForZone('example.com', 'u1', 'admin');
+    expect(remaining.map(b => b.id)).toEqual([second.id, first.id]);
+  });
+});

--- a/backend/src/services/apiTokenService.ts
+++ b/backend/src/services/apiTokenService.ts
@@ -1,0 +1,218 @@
+// backend/src/services/apiTokenService.ts
+// Personal API token storage and verification.
+//
+// Tokens are Cloudflare-style long-lived bearer credentials ("sdns_<40 hex>").
+// Only the sha256 hash of the raw token is persisted; the raw value is returned
+// exactly once at creation and is never written to disk or logged. A byHash map
+// gives O(1) verify lookups, and verification is constant-time to avoid leaking
+// hash bytes through timing. A token inherits its owning user's live privileges
+// at auth time (loaded elsewhere via userService), so no role/zone data is
+// stored here.
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+const TOKENS_FILE = path.join(process.cwd(), 'data', 'api-tokens.json');
+
+export interface ApiToken {
+  id: string;              // `token_${Date.now()}_${crypto.randomBytes(4).toString('hex')}`
+  name: string;
+  userId: string;          // owning user id
+  tokenHash: string;       // sha256 hex of the raw token (full "sdns_..." string)
+  tokenPrefix: string;     // raw.slice(0, 12), display only (e.g. "sdns_1a2b3c4")
+  createdAt: Date;
+  lastUsedAt: Date | null;
+  expiresAt: Date | null;
+  revokedAt: Date | null;
+}
+
+export interface ApiTokenResponse {   // metadata only — NEVER tokenHash / userId
+  id: string;
+  name: string;
+  prefix: string;
+  createdAt: Date;
+  lastUsedAt: Date | null;
+  expiresAt: Date | null;
+}
+
+export interface ApiTokenCreateResult {
+  raw: string;
+  record: ApiToken;
+}
+
+export interface ApiTokenServiceConfig {
+  filePath: string;
+}
+
+export type VerifyResult =
+  | { status: 'valid'; token: ApiToken }
+  | { status: 'not_found' | 'expired' | 'revoked' };
+
+const sha256hex = (raw: string): string =>
+  crypto.createHash('sha256').update(raw).digest('hex');
+
+export class ApiTokenService {
+  private tokens: Map<string, ApiToken> = new Map();
+  private byHash: Map<string, ApiToken> = new Map();
+  private initialized = false;
+  private readonly filePath: string;
+
+  constructor(cfg: ApiTokenServiceConfig = { filePath: TOKENS_FILE }) {
+    this.filePath = cfg.filePath;
+  }
+
+  /**
+   * Load tokens from disk (empty on first run). Rebuilds both the id-keyed and
+   * hash-keyed maps and revives Date fields.
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+
+    try {
+      await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+
+      try {
+        const data = await fs.readFile(this.filePath, 'utf-8');
+        const arr: ApiToken[] = JSON.parse(data);
+
+        arr.forEach(t => {
+          t.createdAt = new Date(t.createdAt);
+          t.lastUsedAt = t.lastUsedAt ? new Date(t.lastUsedAt) : null;
+          t.expiresAt = t.expiresAt ? new Date(t.expiresAt) : null;
+          t.revokedAt = t.revokedAt ? new Date(t.revokedAt) : null;
+          this.tokens.set(t.id, t);
+          this.byHash.set(t.tokenHash, t);
+        });
+
+        console.log(`Loaded ${this.tokens.size} API tokens from disk`);
+      } catch (error: any) {
+        if (error.code === 'ENOENT') {
+          console.log('No existing API tokens file');
+        } else {
+          throw error;
+        }
+      }
+
+      this.initialized = true;
+    } catch (error) {
+      console.error('Failed to initialize API token service:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Persist the full token set to disk. Only hashes/metadata are written; the
+   * raw token never exists on disk.
+   */
+  private async save(): Promise<void> {
+    const arr = Array.from(this.tokens.values());
+    await fs.writeFile(this.filePath, JSON.stringify(arr, null, 2), 'utf-8');
+  }
+
+  /**
+   * Create a token for a user. Returns the raw token exactly once — callers must
+   * surface it immediately and never store it. Only the hash is persisted.
+   */
+  async createToken(userId: string, name: string, expiresInDays?: number): Promise<ApiTokenCreateResult> {
+    if (!this.initialized) await this.initialize();
+
+    const raw = 'sdns_' + crypto.randomBytes(20).toString('hex');
+    const tokenHash = sha256hex(raw);
+    const tokenPrefix = raw.slice(0, 12);
+    const expiresAt = expiresInDays ? new Date(Date.now() + expiresInDays * 86_400_000) : null;
+
+    const record: ApiToken = {
+      id: `token_${Date.now()}_${crypto.randomBytes(4).toString('hex')}`,
+      name,
+      userId,
+      tokenHash,
+      tokenPrefix,
+      createdAt: new Date(),
+      lastUsedAt: null,
+      expiresAt,
+      revokedAt: null,
+    };
+
+    this.tokens.set(record.id, record);
+    this.byHash.set(record.tokenHash, record);
+    await this.save();
+
+    // Never log the raw token or hash — id/name/prefix only.
+    console.log('API token created:', record.id, name, 'for user', userId);
+    return { raw, record };
+  }
+
+  /**
+   * Verify a raw bearer token. Constant-time hash comparison, then revocation
+   * and expiry checks. On success, best-effort touches lastUsedAt at most once
+   * per minute (fire-and-forget save; never blocks the request).
+   */
+  async verifyToken(raw: string): Promise<VerifyResult> {
+    if (!this.initialized) await this.initialize();
+
+    const hash = sha256hex(raw);
+    const candidate = this.byHash.get(hash);
+    if (!candidate) return { status: 'not_found' };
+
+    // Constant-time confirm to avoid leaking the stored hash through timing.
+    if (!crypto.timingSafeEqual(Buffer.from(hash, 'hex'), Buffer.from(candidate.tokenHash, 'hex'))) {
+      return { status: 'not_found' };
+    }
+
+    if (candidate.revokedAt) return { status: 'revoked' };
+    if (candidate.expiresAt && candidate.expiresAt.getTime() < Date.now()) {
+      return { status: 'expired' };
+    }
+
+    // Throttled lastUsedAt touch: at most once per minute, best-effort.
+    if (!candidate.lastUsedAt || Date.now() - candidate.lastUsedAt.getTime() > 60_000) {
+      candidate.lastUsedAt = new Date();
+      this.save().catch(() => { /* best-effort touch; never block auth on a write error */ });
+    }
+
+    return { status: 'valid', token: candidate };
+  }
+
+  /**
+   * List a user's own, non-revoked tokens as metadata only.
+   */
+  async listTokensForUser(userId: string): Promise<ApiTokenResponse[]> {
+    if (!this.initialized) await this.initialize();
+
+    return Array.from(this.tokens.values())
+      .filter(t => t.userId === userId && !t.revokedAt)
+      .map(t => this.toResponse(t));
+  }
+
+  /**
+   * Revoke a token the caller owns. Returns false for unknown ids, other users'
+   * tokens, or already-revoked tokens.
+   */
+  async revokeToken(userId: string, id: string): Promise<boolean> {
+    if (!this.initialized) await this.initialize();
+
+    const t = this.tokens.get(id);
+    if (!t || t.userId !== userId || t.revokedAt) return false;
+
+    t.revokedAt = new Date();
+    await this.save();
+    return true;
+  }
+
+  /**
+   * Convert an ApiToken to its metadata-only response (no hash, no userId).
+   */
+  private toResponse(t: ApiToken): ApiTokenResponse {
+    return {
+      id: t.id,
+      name: t.name,
+      prefix: t.tokenPrefix,
+      createdAt: t.createdAt,
+      lastUsedAt: t.lastUsedAt,
+      expiresAt: t.expiresAt,
+    };
+  }
+}
+
+export const apiTokenService = new ApiTokenService();

--- a/backend/src/services/auditService.ts
+++ b/backend/src/services/auditService.ts
@@ -24,6 +24,11 @@ export enum AuditEventType {
   KEY_DELETED = 'tsig.deleted',
   KEY_ACCESSED = 'tsig.accessed',
 
+  // API token management
+  TOKEN_CREATED = 'token.created',
+  TOKEN_REVOKED = 'token.revoked',
+  TOKEN_AUTH_FAILED = 'token.auth.failed',
+
   // DNS operations
   RECORD_ADDED = 'dns.record.added',
   RECORD_DELETED = 'dns.record.deleted',

--- a/backend/src/services/backupService.ts
+++ b/backend/src/services/backupService.ts
@@ -3,8 +3,8 @@
 
 import { promises as fs } from 'fs';
 import path from 'path';
+import { BackupConfig, resolveBackupConfig } from '../config/backups';
 
-const BACKUPS_DIR = path.join(process.cwd(), 'data', 'backups');
 const MAX_BACKUPS_PER_ZONE = 50;
 
 export interface DNSRecord {
@@ -43,8 +43,15 @@ export interface BackupListItem {
   createdBy: string;
 }
 
-class BackupService {
+export class BackupService {
   private initialized = false;
+  private readonly dir: string;
+  private readonly maxTotalBytes: number;
+
+  constructor(cfg: BackupConfig = resolveBackupConfig()) {
+    this.dir = cfg.dir;
+    this.maxTotalBytes = cfg.maxTotalBytes;
+  }
 
   /**
    * Initialize the service - create backups directory
@@ -53,8 +60,8 @@ class BackupService {
     if (this.initialized) return;
 
     try {
-      await fs.mkdir(BACKUPS_DIR, { recursive: true });
-      console.log(`Backup directory initialized: ${BACKUPS_DIR}`);
+      await fs.mkdir(this.dir, { recursive: true });
+      console.log(`Backup directory initialized: ${this.dir}`);
       this.initialized = true;
     } catch (error) {
       console.error('Failed to initialize backup service:', error);
@@ -68,7 +75,7 @@ class BackupService {
   private getZoneBackupFile(zone: string): string {
     // Sanitize zone name for filename
     const sanitizedZone = zone.replace(/[^a-zA-Z0-9.-]/g, '_');
-    return path.join(BACKUPS_DIR, `${sanitizedZone}.json`);
+    return path.join(this.dir, `${sanitizedZone}.json`);
   }
 
   /**
@@ -173,35 +180,111 @@ class BackupService {
         createdBy: userId,
       };
 
-      // Load existing backups
-      const filePath = this.getZoneBackupFile(zone);
-      let backups: DNSBackup[] = [];
-
-      try {
-        const data = await fs.readFile(filePath, 'utf-8');
-        backups = JSON.parse(data);
-      } catch (error: any) {
-        if (error.code !== 'ENOENT') {
-          throw error;
-        }
+      // A snapshot that alone exceeds the whole budget can never be stored;
+      // reject it rather than evict everything else and still overflow.
+      const soloBytes = this.fileBytes([backup]);
+      if (soloBytes > this.maxTotalBytes) {
+        throw new Error(
+          `Snapshot (${soloBytes} bytes) exceeds the total backup size budget of ${this.maxTotalBytes} bytes`
+        );
       }
 
-      // Add new backup at the beginning
-      backups.unshift(backup);
-
-      // Maintain max backups limit
-      if (backups.length > MAX_BACKUPS_PER_ZONE) {
-        backups = backups.slice(0, MAX_BACKUPS_PER_ZONE);
+      // Work over the whole store in memory so eviction can pick the globally
+      // oldest snapshot regardless of which zone it lives in.
+      const files = await this.loadAllFiles();
+      const targetFile = this.getZoneBackupFile(zone);
+      const targetArr = files.get(targetFile) ?? [];
+      targetArr.unshift(backup);
+      if (targetArr.length > MAX_BACKUPS_PER_ZONE) {
+        targetArr.length = MAX_BACKUPS_PER_ZONE;
       }
+      files.set(targetFile, targetArr);
 
-      // Save to file
-      await fs.writeFile(filePath, JSON.stringify(backups, null, 2), 'utf-8');
+      const changed = new Set<string>([targetFile]);
+      this.evictToBudget(files, backup.id, changed);
+      await this.persistFiles(files, changed);
 
       console.log(`Backup created for zone ${zone}: ${backup.id} by user ${userId}`);
       return backup;
     } catch (error) {
       console.error(`Failed to create backup for zone ${zone}:`, error);
       throw error;
+    }
+  }
+
+  /** Serialized byte size of a zone's backup array as written to disk. */
+  private fileBytes(backups: DNSBackup[]): number {
+    if (backups.length === 0) return 0;
+    return Buffer.byteLength(JSON.stringify(backups, null, 2), 'utf-8');
+  }
+
+  /** Load every zone backup file into memory, keyed by absolute file path. */
+  private async loadAllFiles(): Promise<Map<string, DNSBackup[]>> {
+    const files = new Map<string, DNSBackup[]>();
+    let names: string[];
+    try {
+      names = await fs.readdir(this.dir);
+    } catch (error: any) {
+      if (error.code === 'ENOENT') return files;
+      throw error;
+    }
+    for (const name of names) {
+      if (!name.endsWith('.json')) continue;
+      const filePath = path.join(this.dir, name);
+      const data = await fs.readFile(filePath, 'utf-8');
+      files.set(filePath, JSON.parse(data));
+    }
+    return files;
+  }
+
+  /**
+   * Evict the globally-oldest snapshots (by timestamp, across all zones) until the
+   * total serialized size is within budget. The just-created snapshot (`keepId`)
+   * is never evicted; since its solo size is guaranteed <= budget, the loop always
+   * terminates under budget. Mutates `files` and records touched paths in `changed`.
+   */
+  private evictToBudget(files: Map<string, DNSBackup[]>, keepId: string, changed: Set<string>): void {
+    const sizes = new Map<string, number>();
+    let total = 0;
+    for (const [file, arr] of files) {
+      const bytes = this.fileBytes(arr);
+      sizes.set(file, bytes);
+      total += bytes;
+    }
+    if (total <= this.maxTotalBytes) return;
+
+    // Oldest-first across every zone, excluding the snapshot we must keep.
+    const candidates: { file: string; id: string; timestamp: number }[] = [];
+    for (const [file, arr] of files) {
+      for (const b of arr) {
+        if (b.id !== keepId) candidates.push({ file, id: b.id, timestamp: b.timestamp });
+      }
+    }
+    candidates.sort((a, b) => a.timestamp - b.timestamp);
+
+    for (const c of candidates) {
+      if (total <= this.maxTotalBytes) break;
+      const arr = files.get(c.file);
+      if (!arr) continue;
+      const idx = arr.findIndex(b => b.id === c.id);
+      if (idx === -1) continue;
+      arr.splice(idx, 1);
+      const newBytes = this.fileBytes(arr);
+      total += newBytes - (sizes.get(c.file) ?? 0);
+      sizes.set(c.file, newBytes);
+      changed.add(c.file);
+    }
+  }
+
+  /** Write changed zone files; remove any that were emptied by eviction. */
+  private async persistFiles(files: Map<string, DNSBackup[]>, changed: Set<string>): Promise<void> {
+    for (const file of changed) {
+      const arr = files.get(file) ?? [];
+      if (arr.length === 0) {
+        await fs.rm(file, { force: true });
+      } else {
+        await fs.writeFile(file, JSON.stringify(arr, null, 2), 'utf-8');
+      }
     }
   }
 
@@ -247,13 +330,13 @@ class BackupService {
     if (!this.initialized) await this.initialize();
 
     try {
-      const files = await fs.readdir(BACKUPS_DIR);
+      const files = await fs.readdir(this.dir);
       const allBackups: BackupListItem[] = [];
 
       for (const file of files) {
         if (!file.endsWith('.json')) continue;
 
-        const filePath = path.join(BACKUPS_DIR, file);
+        const filePath = path.join(this.dir, file);
         const data = await fs.readFile(filePath, 'utf-8');
         const backups: DNSBackup[] = JSON.parse(data);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snap-dns",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -34,6 +34,7 @@ import { notificationService } from '../services/notificationService';
 import TSIGKeyManagement from './TSIGKeyManagement';
 import UserManagement from './UserManagement';
 import SSOConfiguration from './SSOConfiguration';
+import TokenManagement from './TokenManagement';
 import AuditLog from './AuditLog';
 import { useAuth } from '../context/AuthContext';
 import { useNotification } from '../context/NotificationContext';
@@ -475,7 +476,8 @@ function Settings() {
             <Tab label="Keys" {...a11yProps(1)} />
             <Tab label="Users" {...a11yProps(2)} />
             <Tab label="SSO" {...a11yProps(3)} />
-            {user?.role === 'admin' && <Tab label="Audit Logs" {...a11yProps(4)} />}
+            <Tab label="API Tokens" {...a11yProps(4)} />
+            {user?.role === 'admin' && <Tab label="Audit Logs" {...a11yProps(5)} />}
           </Tabs>
         </Box>
 
@@ -637,9 +639,16 @@ function Settings() {
           </Box>
         </TabPanel>
 
+        {/* API Tokens Tab (all roles - personal tokens) */}
+        <TabPanel value={currentTab} index={4}>
+          <Box sx={{ p: 3 }}>
+            <TokenManagement />
+          </Box>
+        </TabPanel>
+
         {/* Audit Logs Tab (Admin only) */}
         {user?.role === 'admin' && (
-          <TabPanel value={currentTab} index={4}>
+          <TabPanel value={currentTab} index={5}>
             <Box sx={{ p: 3 }}>
               <AuditLog />
             </Box>

--- a/src/components/TokenManagement.tsx
+++ b/src/components/TokenManagement.tsx
@@ -1,0 +1,336 @@
+// src/components/TokenManagement.tsx
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Alert,
+  Chip,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import VpnKeyIcon from '@mui/icons-material/VpnKey';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { tokenService, ApiToken } from '../services/tokenService';
+import { useNotification } from '../context/NotificationContext';
+
+// Expiry choices offered in the create dialog. A value of 0 means "Never"
+// and is translated to `undefined` (no expiry) when calling the API.
+const EXPIRY_OPTIONS: Array<{ label: string; value: number }> = [
+  { label: 'Never', value: 0 },
+  { label: '30 days', value: 30 },
+  { label: '60 days', value: 60 },
+  { label: '90 days', value: 90 },
+  { label: '365 days', value: 365 },
+];
+
+function formatDate(value: string | null): string {
+  if (!value) return 'Never';
+  return new Date(value).toLocaleString();
+}
+
+export default function TokenManagement() {
+  const { showSuccess, showError } = useNotification();
+  const [tokens, setTokens] = useState<ApiToken[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  // Create dialog state
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [formError, setFormError] = useState('');
+  const [name, setName] = useState('');
+  const [expiresInDays, setExpiresInDays] = useState(0);
+  const [creating, setCreating] = useState(false);
+  // The raw token is only ever held in memory for the reveal-once view.
+  const [createdToken, setCreatedToken] = useState<string | null>(null);
+
+  // Revoke dialog state
+  const [revokeDialogOpen, setRevokeDialogOpen] = useState(false);
+  const [tokenToRevoke, setTokenToRevoke] = useState<ApiToken | null>(null);
+
+  useEffect(() => {
+    loadTokens();
+  }, []);
+
+  const loadTokens = async () => {
+    try {
+      setLoading(true);
+      setError('');
+      const data = await tokenService.listTokens();
+      setTokens(data);
+    } catch (err: any) {
+      setError(err.message || 'Failed to load API tokens');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleOpenDialog = () => {
+    setName('');
+    setExpiresInDays(0);
+    setFormError('');
+    setCreatedToken(null);
+    setDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setDialogOpen(false);
+    setFormError('');
+    setName('');
+    setExpiresInDays(0);
+    // Clear any revealed token so it never lingers in memory.
+    setCreatedToken(null);
+    loadTokens();
+  };
+
+  const handleSubmit = async () => {
+    if (!name.trim()) {
+      setFormError('Token name is required');
+      return;
+    }
+    try {
+      setFormError('');
+      setCreating(true);
+      const result = await tokenService.createToken(
+        name.trim(),
+        expiresInDays > 0 ? expiresInDays : undefined
+      );
+      setCreatedToken(result.token);
+    } catch (err: any) {
+      setFormError(err.message || 'Failed to create token');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!createdToken) return;
+    try {
+      await navigator.clipboard.writeText(createdToken);
+      showSuccess('Copied to clipboard');
+    } catch (err: any) {
+      showError('Failed to copy to clipboard');
+    }
+  };
+
+  const handleRevoke = async () => {
+    if (!tokenToRevoke) return;
+    try {
+      await tokenService.revokeToken(tokenToRevoke.id);
+      showSuccess('Token revoked');
+      setRevokeDialogOpen(false);
+      setTokenToRevoke(null);
+      loadTokens();
+    } catch (err: any) {
+      showError(err.message || 'Failed to revoke token');
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" p={3} role="status">
+        <CircularProgress aria-label="Loading" />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
+        <Box display="flex" alignItems="center" gap={1}>
+          <VpnKeyIcon />
+          <Typography variant="h6">API Tokens</Typography>
+        </Box>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={handleOpenDialog}
+        >
+          Create Token
+        </Button>
+      </Box>
+
+      {error && (
+        <Alert severity="error" onClose={() => setError('')} sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      <Alert severity="info" sx={{ mb: 2 }}>
+        API tokens grant programmatic access with your current permissions. Treat them like
+        passwords.
+      </Alert>
+
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Prefix</TableCell>
+              <TableCell>Created</TableCell>
+              <TableCell>Last Used</TableCell>
+              <TableCell>Expires</TableCell>
+              <TableCell>Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {tokens.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={6} align="center">
+                  <Typography color="text.secondary" py={2}>
+                    No API tokens yet. Create one to get started.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              tokens.map((token) => (
+                <TableRow key={token.id}>
+                  <TableCell>{token.name}</TableCell>
+                  <TableCell>
+                    <Chip
+                      label={token.prefix}
+                      size="small"
+                      sx={{ fontFamily: 'monospace' }}
+                    />
+                  </TableCell>
+                  <TableCell>{formatDate(token.createdAt)}</TableCell>
+                  <TableCell>{formatDate(token.lastUsedAt)}</TableCell>
+                  <TableCell>{formatDate(token.expiresAt)}</TableCell>
+                  <TableCell>
+                    <IconButton
+                      size="small"
+                      onClick={() => {
+                        setTokenToRevoke(token);
+                        setRevokeDialogOpen(true);
+                      }}
+                      title="Revoke token"
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {/* Create Dialog */}
+      <Dialog open={dialogOpen} onClose={handleCloseDialog} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          {createdToken ? 'Token Created' : 'Create API Token'}
+        </DialogTitle>
+        <DialogContent>
+          {createdToken ? (
+            // Reveal-once view: the raw token is shown a single time.
+            <Box display="flex" flexDirection="column" gap={2} mt={1}>
+              <Alert severity="warning">
+                Copy this token now. You will not be able to see it again.
+              </Alert>
+              <Box display="flex" alignItems="center" gap={1}>
+                <TextField
+                  label="API Token"
+                  value={createdToken}
+                  fullWidth
+                  InputProps={{
+                    readOnly: true,
+                    sx: { fontFamily: 'monospace' },
+                  }}
+                />
+                <IconButton onClick={handleCopy} title="Copy token">
+                  <ContentCopyIcon />
+                </IconButton>
+              </Box>
+            </Box>
+          ) : (
+            <Box display="flex" flexDirection="column" gap={2} mt={1}>
+              {formError && (
+                <Alert severity="error" onClose={() => setFormError('')}>
+                  {formError}
+                </Alert>
+              )}
+              <TextField
+                label="Token Name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+                fullWidth
+                autoFocus
+                helperText="A friendly name to identify this token"
+              />
+              <FormControl fullWidth>
+                <InputLabel id="token-expiry-label">Expiration</InputLabel>
+                <Select
+                  labelId="token-expiry-label"
+                  value={expiresInDays}
+                  onChange={(e) => setExpiresInDays(Number(e.target.value))}
+                  label="Expiration"
+                >
+                  {EXPIRY_OPTIONS.map((option) => (
+                    <MenuItem key={option.value} value={option.value}>
+                      {option.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          {createdToken ? (
+            <Button onClick={handleCloseDialog} variant="contained">
+              Done
+            </Button>
+          ) : (
+            <>
+              <Button onClick={handleCloseDialog}>Cancel</Button>
+              <Button
+                onClick={handleSubmit}
+                variant="contained"
+                disabled={creating}
+                startIcon={creating ? <CircularProgress size={20} /> : undefined}
+              >
+                Create
+              </Button>
+            </>
+          )}
+        </DialogActions>
+      </Dialog>
+
+      {/* Revoke Confirmation Dialog */}
+      <Dialog open={revokeDialogOpen} onClose={() => setRevokeDialogOpen(false)}>
+        <DialogTitle>Revoke Token</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Revoke token "{tokenToRevoke?.name}"? Any client using it will immediately lose
+            access. This cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setRevokeDialogOpen(false)}>Cancel</Button>
+          <Button onClick={handleRevoke} color="error" variant="contained">
+            Revoke
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/components/__tests__/TokenManagement.test.tsx
+++ b/src/components/__tests__/TokenManagement.test.tsx
@@ -1,0 +1,114 @@
+// src/components/__tests__/TokenManagement.test.tsx
+import React from 'react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import TokenManagement from '../TokenManagement';
+
+// The component talks to the backend only through this API client, mocked
+// per test.
+const mockListTokens = jest.fn();
+const mockCreateToken = jest.fn();
+const mockRevokeToken = jest.fn();
+jest.mock('../../services/tokenService', () => ({
+  tokenService: {
+    listTokens: (...args: unknown[]) => mockListTokens(...args),
+    createToken: (...args: unknown[]) => mockCreateToken(...args),
+    revokeToken: (...args: unknown[]) => mockRevokeToken(...args),
+  },
+}));
+
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1', username: 't', role: 'editor' } }),
+}));
+
+const mockShowSuccess = jest.fn();
+const mockShowError = jest.fn();
+jest.mock('../../context/NotificationContext', () => ({
+  useNotification: () => ({
+    showSuccess: mockShowSuccess,
+    showError: mockShowError,
+    showInfo: jest.fn(),
+  }),
+}));
+
+const sampleToken = {
+  id: 'token_1',
+  name: 'ci-runner',
+  prefix: 'sdns_1a2b3c',
+  createdAt: '2026-07-13T12:00:00.000Z',
+  lastUsedAt: null,
+  expiresAt: null,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockListTokens.mockResolvedValue([sampleToken]);
+  mockCreateToken.mockResolvedValue({
+    token: 'sdns_' + 'a'.repeat(40),
+    id: 'token_2',
+    name: 'new-token',
+    prefix: 'sdns_aaaaaa',
+    createdAt: '2026-07-13T12:00:00.000Z',
+    expiresAt: null,
+  });
+  mockRevokeToken.mockResolvedValue(undefined);
+});
+
+describe('TokenManagement', () => {
+  it('renders a row per token with metadata and "Never" for null fields', async () => {
+    render(<TokenManagement />);
+
+    expect(await screen.findByText('ci-runner')).toBeInTheDocument();
+    expect(screen.getByText('sdns_1a2b3c')).toBeInTheDocument();
+    // Both lastUsedAt and expiresAt are null -> two "Never" cells.
+    expect(screen.getAllByText('Never')).toHaveLength(2);
+  });
+
+  it('creates a token and reveals the raw value exactly once', async () => {
+    render(<TokenManagement />);
+    await screen.findByText('ci-runner');
+
+    fireEvent.click(screen.getByRole('button', { name: /create token/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.change(within(dialog).getByLabelText(/token name/i), {
+      target: { value: 'new-token' },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Create' }));
+
+    // Called with no expiry (undefined) since "Never" is the default.
+    await waitFor(() => {
+      expect(mockCreateToken).toHaveBeenCalledWith('new-token', undefined);
+    });
+
+    const rawToken = 'sdns_' + 'a'.repeat(40);
+    expect(await screen.findByDisplayValue(rawToken)).toBeInTheDocument();
+    expect(
+      screen.getByText(/you will not be able to see it again/i)
+    ).toBeInTheDocument();
+    // A copy control exists in the reveal view.
+    expect(screen.getByTitle('Copy token')).toBeInTheDocument();
+
+    // Clicking "Done" clears the raw token from view.
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }));
+    await waitFor(() => {
+      expect(screen.queryByDisplayValue(rawToken)).not.toBeInTheDocument();
+    });
+  });
+
+  it('revokes a token after confirmation and reloads', async () => {
+    render(<TokenManagement />);
+    await screen.findByText('ci-runner');
+
+    fireEvent.click(screen.getByTitle('Revoke token'));
+
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Revoke' }));
+
+    await waitFor(() => {
+      expect(mockRevokeToken).toHaveBeenCalledWith('token_1');
+    });
+    expect(mockShowSuccess).toHaveBeenCalledWith('Token revoked');
+    // Initial load + reload after revoke.
+    expect(mockListTokens).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/tokenService.ts
+++ b/src/services/tokenService.ts
@@ -1,0 +1,105 @@
+// src/services/tokenService.ts
+// Frontend service for managing personal API tokens stored server-side.
+// Mirrors tsigKeyService: session-cookie auth via credentials:'include'.
+import { getApiUrl } from '../utils/apiUrl';
+
+const API_URL = getApiUrl();
+
+// Metadata for an existing token (never includes the raw token or its hash).
+export interface ApiToken {
+  id: string;
+  name: string;
+  prefix: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+}
+
+// Result of creating a token; the raw `token` is shown exactly once.
+export interface CreatedToken {
+  token: string;
+  id: string;
+  name: string;
+  prefix: string;
+  createdAt: string;
+  expiresAt: string | null;
+}
+
+class TokenService {
+  /**
+   * List the caller's own, non-revoked tokens (metadata only).
+   */
+  async listTokens(): Promise<ApiToken[]> {
+    try {
+      const response = await fetch(`${API_URL}/api/tokens`, {
+        method: 'GET',
+        credentials: 'include',
+      });
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}));
+        throw new Error(error.error || 'Failed to fetch API tokens');
+      }
+
+      const data = await response.json();
+      return data.tokens || [];
+    } catch (error) {
+      console.error('List API tokens error:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Create a new API token. The returned raw token is displayed once and
+   * never persisted anywhere by the client.
+   */
+  async createToken(name: string, expiresInDays?: number): Promise<CreatedToken> {
+    try {
+      const body: { name: string; expiresInDays?: number } = { name };
+      if (typeof expiresInDays === 'number') {
+        body.expiresInDays = expiresInDays;
+      }
+
+      const response = await fetch(`${API_URL}/api/tokens`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}));
+        throw new Error(error.error || 'Failed to create API token');
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error('Create API token error:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Revoke (delete) one of the caller's own tokens.
+   */
+  async revokeToken(id: string): Promise<void> {
+    try {
+      const response = await fetch(`${API_URL}/api/tokens/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}));
+        throw new Error(error.error || 'Failed to revoke API token');
+      }
+    } catch (error) {
+      console.error('Revoke API token error:', error);
+      throw error;
+    }
+  }
+}
+
+export const tokenService = new TokenService();


### PR DESCRIPTION
Two hardening changes on top of `main`.

## feat(auth): personal API tokens for programmatic access
User-generated API tokens so DNS operations can be driven by scripts/CI, reusing the existing RBAC and zone/key allowlists.

- **apiTokenService**: tokens are `sdns_<40hex>`; only the sha256 hash is persisted (`data/api-tokens.json`), the raw value is returned exactly once and never logged. O(1) verify via a hash map with revocation/expiry checks and a throttled `lastUsedAt` touch.
- **requireAuth** gains a bearer fallback (session stays primary): a token authenticates as its owner with the owner's **live** privileges (role/allowlists re-loaded per request, so revocations apply immediately). `requireSessionAuth` blocks bearer from the token-management routes.
- **Routes `/api/tokens`**: POST create (session-only, returns raw once), GET list (own, metadata-only), DELETE revoke (session-only); rate-limited and audited.
- **Frontend**: "API Tokens" tab in Settings with a create-once reveal (copy + warning) and revoke.

Hardening from the review pass: create/revoke require the current password (a not-yet-rotated account can't mint a surviving credential); rate limiters key per-principal (bearer throttled per token); token lifetime capped at 365 days.

## fix(backups): bound snapshot disk usage with a size budget and zone gate
Server-side snapshots could grow without bound and fill the disk:

- The create route did no zone-access check — gate it with the same deny-by-default `checkZoneAccess` used by the zone routes (also closes an IDOR/junk-file gap).
- The 50-per-zone cap bounded count, not bytes. Add a global size budget (`BACKUP_MAX_TOTAL_SIZE_MB`, default 512); reject a single snapshot larger than the budget and otherwise evict the globally-oldest snapshots until back under budget.

## Tests
apiTokenService + tokenAuth HTTP integration (RBAC through bearer, viewer blocked from writes, expired/revoked/invalid → 401, session precedence, password-change gate), principalKey, TokenManagement component; backupService budget/eviction + zone-gate integration. Backend 353/353 + build clean; frontend typecheck + token/settings tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)