### PR TITLE
Fix split-horizon view conflation: target the explicitly selected key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2026-07-21
+
+### Fixed
+
+- **Split-horizon views are no longer conflated.** When the same zone name
+  existed under two TSIG keys (e.g. an internal and an external view), a record
+  edit was routed to whichever key the backend happened to resolve first by zone
+  name, so an internal-view change could land on the external server (and vice
+  versa). Every zone operation now carries the explicitly selected key, and the
+  backend targets that exact key/view.
+
+### Changed
+
+- **Zone API operations now require an explicit `keyId`.** `GET /api/zones/:zone`
+  takes a `keyId` query parameter; the record add/delete/update and batch
+  endpoints take a `keyId` in the request body. The backend authorizes the key
+  (it must be in the caller's allowlist and configured for the zone) and resolves
+  the DNS server from it, instead of guessing a key from the zone name. Requests
+  without a `keyId` are rejected. The frontend sends the selected key
+  automatically; any programmatic API client must be updated to include it.
+- **Pending changes apply per (zone, key).** The apply flow groups queued changes
+  by both zone and key, so a batch is sent through the exact view each change was
+  queued under — changes across different keys are never collapsed into one
+  transaction. The confirmation dialog now names the key/view for each group.
+- **Snapshots record the key/view they were taken through** (`keyId`), and
+  compare/restore read and write that same view. Older snapshots without a
+  recorded key fall back to a key on the same server (then any key serving the
+  zone).
+
 ## [3.1.0] - 2026-07-13
 
 ### Added

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "main": "dist/server.js",
   "scripts": {
     "start": "node dist/server.js",

--- a/backend/src/__tests__/integration/allowlistSemantics.integration.test.ts
+++ b/backend/src/__tests__/integration/allowlistSemantics.integration.test.ts
@@ -100,7 +100,8 @@ describe('Allowlist empty-set semantics (deny-by-default)', () => {
         allowedKeyIds: [keyAId],
       });
       const { agent } = await loginAgent(app, 'okzone', 'okzone-pass-123');
-      const res = await agent.get('/api/zones/example.com');
+      // keyId is now required to identify the view; keyA serves example.com.
+      const res = await agent.get(`/api/zones/example.com?keyId=${keyAId}`);
       expect(res.status).toBe(200);
       expect(res.body.code).not.toBe('PERMISSION_DENIED');
     });
@@ -109,7 +110,8 @@ describe('Allowlist empty-set semantics (deny-by-default)', () => {
       // admin1 has empty allowedZones but the admin role bypasses the gate.
       jest.spyOn(dnsService, 'fetchZoneRecords').mockResolvedValue([] as never);
       const { agent } = await loginAgent(app, 'admin1', 'admin-pass-123');
-      const res = await agent.get('/api/zones/example.com');
+      // Admin may use any key; keyA serves example.com.
+      const res = await agent.get(`/api/zones/example.com?keyId=${keyAId}`);
       expect(res.status).toBe(200);
     });
   });

--- a/backend/src/__tests__/integration/rbac.integration.test.ts
+++ b/backend/src/__tests__/integration/rbac.integration.test.ts
@@ -28,12 +28,20 @@ const validRecord = {
 
 describe('RBAC on mutation routes (HTTP)', () => {
   let app: Express;
+  let editorKeyId: string;
 
   beforeAll(async () => {
     app = buildTestApp();
     await seedUser({ username: 'viewer1', password: 'viewer-pass-123', role: UserRole.VIEWER });
+    // A real key serving the zone; the write path now resolves the key by the
+    // explicit keyId, so the editor must be granted it.
+    const key = await tsigKeyService.createKey('seed', {
+      name: 'rbac-key', server: '192.0.2.53', keyName: 'rbac-key.',
+      keyValue: 'c25hcC1kbnMtdGVzdC1rZXk=', algorithm: 'hmac-sha256', zones: ['example.com'],
+    });
+    editorKeyId = key.id;
     // Grant the zone explicitly: allowedZones is deny-by-default (empty => no zones).
-    await seedUser({ username: 'editor1', password: 'editor-pass-123', role: UserRole.EDITOR, allowedZones: ['example.com'] });
+    await seedUser({ username: 'editor1', password: 'editor-pass-123', role: UserRole.EDITOR, allowedZones: ['example.com'], allowedKeyIds: [editorKeyId] });
   });
 
   describe('TSIG key creation', () => {
@@ -73,18 +81,6 @@ describe('RBAC on mutation routes (HTTP)', () => {
     });
 
     it('lets an editor through the full guard chain to the DNS layer (200)', async () => {
-      jest.spyOn(tsigKeyService, 'getKeyForZone').mockResolvedValue({
-        id: 'key-1',
-        name: 'test-key',
-        server: '192.0.2.53',
-        keyName: 'test-key.',
-        keyValue: 'plaintext-secret',
-        algorithm: 'hmac-sha256',
-        zones: ['example.com'],
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        createdBy: 'someone',
-      });
       const addSpy = jest
         .spyOn(dnsService, 'addRecord')
         .mockResolvedValue({ success: true } as never);
@@ -92,7 +88,7 @@ describe('RBAC on mutation routes (HTTP)', () => {
       const { agent } = await loginAgent(app, 'editor1', 'editor-pass-123');
       const res = await agent
         .post('/api/zones/example.com/records')
-        .send({ record: validRecord });
+        .send({ keyId: editorKeyId, record: validRecord });
 
       expect(res.status).toBe(200);
       expect(addSpy).toHaveBeenCalledTimes(1);
@@ -100,7 +96,7 @@ describe('RBAC on mutation routes (HTTP)', () => {
       const [zoneArg, recordArg, keyConfigArg] = addSpy.mock.calls[0];
       expect(zoneArg).toBe('example.com');
       expect(recordArg).toMatchObject({ type: 'A', value: '192.0.2.10' });
-      expect(keyConfigArg).toMatchObject({ keyName: 'test-key.', server: '192.0.2.53' });
+      expect(keyConfigArg).toMatchObject({ id: editorKeyId, keyName: 'rbac-key.', server: '192.0.2.53' });
     });
   });
 });

--- a/backend/src/__tests__/integration/splitView.integration.test.ts
+++ b/backend/src/__tests__/integration/splitView.integration.test.ts
@@ -1,0 +1,147 @@
+// backend/src/__tests__/integration/splitView.integration.test.ts
+// HTTP-level proof that zone operations target the EXPLICITLY selected TSIG key
+// (i.e. the split-horizon "view"), not whichever key happens to list the zone
+// name first. Two keys ("internal" and "external") both serve the same zone name
+// on different servers; a request must carry keyId and be dispatched to that
+// key's server. The DNS exec layer is stubbed so these stay pure route tests.
+import type { Express } from 'express';
+import { buildTestApp, seedUser, loginAgent } from './testApp';
+import { UserRole } from '../../types/auth';
+import { dnsService } from '../../services/dnsService';
+import { tsigKeyService } from '../../services/tsigKeyService';
+
+const SHARED_ZONE = 'split.example.com';
+
+const oldRecord = { name: 'ns5.split.example.com', type: 'A', value: '192.0.2.5', ttl: 3600, class: 'IN' };
+const newRecord = { name: 'ns5.split.example.com', type: 'A', value: '192.0.2.5', ttl: 300, class: 'IN' };
+
+describe('Split-horizon: operations target the explicitly selected key (HTTP)', () => {
+  let app: Express;
+  let internalKeyId: string;
+  let externalKeyId: string;
+  let otherZoneKeyId: string;
+
+  beforeAll(async () => {
+    app = buildTestApp();
+
+    // Two keys, same zone name, different servers — the split-view setup.
+    const internal = await tsigKeyService.createKey('seed', {
+      name: 'internal', server: '10.0.0.53', keyName: 'internal.', keyValue: 'aW50ZXJuYWwtc2VjcmV0',
+      algorithm: 'hmac-sha256', zones: [SHARED_ZONE],
+    });
+    const external = await tsigKeyService.createKey('seed', {
+      name: 'external', server: '203.0.113.53', keyName: 'external.', keyValue: 'ZXh0ZXJuYWwtc2VjcmV0',
+      algorithm: 'hmac-sha256', zones: [SHARED_ZONE],
+    });
+    // A key the editor is allowed to use but which does NOT serve SHARED_ZONE.
+    const other = await tsigKeyService.createKey('seed', {
+      name: 'other', server: '198.51.100.53', keyName: 'other.', keyValue: 'b3RoZXItc2VjcmV0',
+      algorithm: 'hmac-sha256', zones: ['other.example.com'],
+    });
+    internalKeyId = internal.id;
+    externalKeyId = external.id;
+    otherZoneKeyId = other.id;
+
+    // Admin bypasses allowlists; editor is scoped to the zone + only the two
+    // split-view keys and the "other" key (to test the serves-zone check).
+    await seedUser({ username: 'admin1', password: 'admin-pass-123', role: UserRole.ADMIN });
+    await seedUser({
+      username: 'editor1', password: 'editor-pass-123', role: UserRole.EDITOR,
+      allowedZones: [SHARED_ZONE], allowedKeyIds: [internalKeyId, otherZoneKeyId],
+    });
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('PATCH with the internal keyId dispatches to the internal server', async () => {
+    const spy = jest.spyOn(dnsService, 'updateRecord').mockResolvedValue({ success: true } as never);
+    const { agent } = await loginAgent(app, 'admin1', 'admin-pass-123');
+
+    const res = await agent
+      .patch(`/api/zones/${SHARED_ZONE}/records`)
+      .send({ keyId: internalKeyId, oldRecord, newRecord });
+
+    expect(res.status).toBe(200);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const keyConfig = spy.mock.calls[0][3];
+    expect(keyConfig).toMatchObject({ id: internalKeyId, server: '10.0.0.53' });
+  });
+
+  it('PATCH with the external keyId dispatches to the external server (same zone name)', async () => {
+    const spy = jest.spyOn(dnsService, 'updateRecord').mockResolvedValue({ success: true } as never);
+    const { agent } = await loginAgent(app, 'admin1', 'admin-pass-123');
+
+    const res = await agent
+      .patch(`/api/zones/${SHARED_ZONE}/records`)
+      .send({ keyId: externalKeyId, oldRecord, newRecord });
+
+    expect(res.status).toBe(200);
+    const keyConfig = spy.mock.calls[0][3];
+    expect(keyConfig).toMatchObject({ id: externalKeyId, server: '203.0.113.53' });
+  });
+
+  it('rejects a write with no keyId and never touches DNS', async () => {
+    const spy = jest.spyOn(dnsService, 'updateRecord');
+    const { agent } = await loginAgent(app, 'admin1', 'admin-pass-123');
+
+    const res = await agent
+      .patch(`/api/zones/${SHARED_ZONE}/records`)
+      .send({ oldRecord, newRecord });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('MISSING_CONFIG');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('forbids a keyId the user is not allowed to use (403)', async () => {
+    const spy = jest.spyOn(dnsService, 'updateRecord');
+    // editor1 is NOT granted externalKeyId.
+    const { agent } = await loginAgent(app, 'editor1', 'editor-pass-123');
+
+    const res = await agent
+      .patch(`/api/zones/${SHARED_ZONE}/records`)
+      .send({ keyId: externalKeyId, oldRecord, newRecord });
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('PERMISSION_DENIED');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a keyId that does not serve the requested zone', async () => {
+    const spy = jest.spyOn(dnsService, 'updateRecord');
+    const { agent } = await loginAgent(app, 'editor1', 'editor-pass-123');
+
+    // otherZoneKeyId is allowed for the user but serves a different zone.
+    const res = await agent
+      .patch(`/api/zones/${SHARED_ZONE}/records`)
+      .send({ keyId: otherZoneKeyId, oldRecord, newRecord });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('MISSING_CONFIG');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('GET reads the zone via the server of the requested keyId', async () => {
+    const spy = jest.spyOn(dnsService, 'fetchZoneRecords').mockResolvedValue([] as never);
+    const { agent } = await loginAgent(app, 'admin1', 'admin-pass-123');
+
+    const res = await agent.get(`/api/zones/${SHARED_ZONE}?keyId=${externalKeyId}`);
+
+    expect(res.status).toBe(200);
+    const keyConfig = spy.mock.calls[0][1];
+    expect(keyConfig).toMatchObject({ id: externalKeyId, server: '203.0.113.53' });
+  });
+
+  it('batch dispatches to the explicitly selected key', async () => {
+    const spy = jest.spyOn(dnsService, 'applyBatch').mockResolvedValue({ success: true } as never);
+    const { agent } = await loginAgent(app, 'admin1', 'admin-pass-123');
+
+    const res = await agent
+      .post(`/api/zones/${SHARED_ZONE}/records/batch`)
+      .send({ keyId: internalKeyId, changes: [{ op: 'update', oldRecord, newRecord }] });
+
+    expect(res.status).toBe(200);
+    const keyConfig = spy.mock.calls[0][2];
+    expect(keyConfig).toMatchObject({ id: internalKeyId, server: '10.0.0.53' });
+  });
+});

--- a/backend/src/middleware/validation.ts
+++ b/backend/src/middleware/validation.ts
@@ -65,15 +65,22 @@ export const DNSRecordSchema = z.object({
 /**
  * Zone operation request schemas
  */
+// keyId identifies which TSIG key/view the operation targets. It is optional at
+// the schema layer (so the field survives Zod's unknown-key stripping) and its
+// presence is enforced uniformly by resolveZoneKey in the route handler, which
+// also authorizes the key and checks it serves the zone.
 export const AddRecordRequestSchema = z.object({
+  keyId: z.string().optional(),
   record: DNSRecordSchema
 });
 
 export const DeleteRecordRequestSchema = z.object({
+  keyId: z.string().optional(),
   record: DNSRecordSchema
 });
 
 export const UpdateRecordRequestSchema = z.object({
+  keyId: z.string().optional(),
   oldRecord: DNSRecordSchema,
   newRecord: DNSRecordSchema
 });
@@ -90,6 +97,7 @@ export const BatchChangeSchema = z.object({
 });
 
 export const BatchRequestSchema = z.object({
+  keyId: z.string().optional(),
   changes: z.array(BatchChangeSchema).min(1, 'At least one change is required').max(1000, 'Too many changes in one batch')
 });
 

--- a/backend/src/routes/backupRoutes.ts
+++ b/backend/src/routes/backupRoutes.ts
@@ -109,7 +109,7 @@ router.post('/zone/:zone', requireAuth, requireWriteAccess, requirePasswordCurre
     const authReq = req as AuthenticatedRequest;
     const user = authReq.user!;
     const { zone } = req.params;
-    const { records, server, type, description } = req.body;
+    const { records, server, keyId, type, description } = req.body;
 
     // Validate required fields
     if (!records || !Array.isArray(records)) {
@@ -138,6 +138,7 @@ router.post('/zone/:zone', requireAuth, requireWriteAccess, requirePasswordCurre
 
     const backup = await backupService.createBackup(zone, records, user.userId, {
       server,
+      keyId,
       type,
       description,
     });

--- a/backend/src/routes/zoneRoutes.ts
+++ b/backend/src/routes/zoneRoutes.ts
@@ -47,6 +47,84 @@ const ErrorCodes = {
 // Add type for error codes
 type ErrorCode = typeof ErrorCodes[keyof typeof ErrorCodes];
 
+// Result of resolving the explicitly-selected TSIG key for a request.
+type KeyResolution =
+  | { ok: true; keyConfig: ZoneConfig }
+  | { ok: false; status: number; code: ErrorCode; error: string; details?: unknown };
+
+// Resolve the TSIG key a request must use by its EXPLICIT keyId, never by zone
+// name. In split-horizon DNS the same zone name exists under two keys (an
+// internal and an external view); resolving by zone name alone silently picks
+// whichever key sorts first, so an internal edit could land on the external
+// server. Requiring keyId makes the target view unambiguous.
+//
+// Authorization order: the key must be in the caller's allowlist (admins may use
+// any key), it must exist, and it must actually serve the requested zone (an
+// empty zones list is a wildcard that serves any zone).
+async function resolveZoneKey(
+  user: { role: string; userId: string; allowedKeyIds: string[] },
+  zone: string,
+  keyId: unknown
+): Promise<KeyResolution> {
+  if (!keyId || typeof keyId !== 'string') {
+    return {
+      ok: false,
+      status: 400,
+      code: ErrorCodes.MISSING_CONFIG,
+      error: 'A keyId is required to identify which TSIG key/view to use',
+      details: { missingFields: ['keyId'] },
+    };
+  }
+
+  let allowedKeyIds = user.allowedKeyIds;
+  if (user.role === 'admin') {
+    const allKeys = await tsigKeyService.listKeys();
+    allowedKeyIds = allKeys.map(k => k.id);
+  }
+  if (!allowedKeyIds.includes(keyId)) {
+    return {
+      ok: false,
+      status: 403,
+      code: ErrorCodes.PERMISSION_DENIED,
+      error: 'Access denied to the specified key',
+      details: { keyId },
+    };
+  }
+
+  const tsigKey = await tsigKeyService.getKey(keyId);
+  if (!tsigKey) {
+    return {
+      ok: false,
+      status: 404,
+      code: ErrorCodes.MISSING_CONFIG,
+      error: 'The specified TSIG key does not exist',
+      details: { keyId },
+    };
+  }
+
+  const servesZone = tsigKey.zones.length === 0 || tsigKey.zones.includes(zone);
+  if (!servesZone) {
+    return {
+      ok: false,
+      status: 400,
+      code: ErrorCodes.MISSING_CONFIG,
+      error: 'The selected key is not configured for this zone',
+      details: { zone, keyId },
+    };
+  }
+
+  return {
+    ok: true,
+    keyConfig: {
+      server: tsigKey.server,
+      keyName: tsigKey.keyName,
+      keyValue: tsigKey.keyValue, // Already decrypted by getKey
+      algorithm: tsigKey.algorithm,
+      id: tsigKey.id,
+    },
+  };
+}
+
 // Get zone records - requires authentication and rate limiting
 router.get('/:zone', dnsQueryLimiter, requireAuth, async (req: Request, res: Response) => {
   try {
@@ -63,36 +141,20 @@ router.get('/:zone', dnsQueryLimiter, requireAuth, async (req: Request, res: Res
       });
     }
 
-    // For admins, get all key IDs; otherwise use the user's allowed keys
-    let allowedKeyIds = user.allowedKeyIds;
-    if (user.role === 'admin') {
-      // Admins have access to all keys
-      const allKeys = await tsigKeyService.listKeys();
-      allowedKeyIds = allKeys.map(k => k.id);
-    }
-
-    // Fetch TSIG key from storage for this zone
-    const tsigKey = await tsigKeyService.getKeyForZone(zone, user.userId, allowedKeyIds);
-
-    if (!tsigKey) {
-      return res.status(403).json({
+    // Resolve the key by the explicitly requested keyId (query param), so a
+    // split-horizon zone is read from the exact view the user selected.
+    const resolved = await resolveZoneKey(user, zone, req.query.keyId);
+    if (!resolved.ok) {
+      return res.status(resolved.status).json({
         success: false,
-        code: ErrorCodes.MISSING_CONFIG,
-        error: 'No TSIG key found for this zone. Please configure a key first.',
-        details: { zone }
+        code: resolved.code,
+        error: resolved.error,
+        details: resolved.details,
       });
     }
+    const keyConfig = resolved.keyConfig;
 
-    // Build key config from stored key
-    const keyConfig: ZoneConfig = {
-      server: tsigKey.server,
-      keyName: tsigKey.keyName,
-      keyValue: tsigKey.keyValue, // Already decrypted
-      algorithm: tsigKey.algorithm,
-      id: tsigKey.id
-    };
-
-    console.log('Fetching records for zone:', zone, 'using stored key:', tsigKey.name);
+    console.log('Fetching records for zone:', zone, 'using key id:', keyConfig.id);
 
     const records = await dnsService.fetchZoneRecords(zone, keyConfig);
     res.json({ success: true, records });
@@ -171,32 +233,18 @@ router.post(
       });
     }
 
-    // For admins, get all key IDs; otherwise use the user's allowed keys
-    let allowedKeyIds = user.allowedKeyIds;
-    if (user.role === 'admin') {
-      const allKeys = await tsigKeyService.listKeys();
-      allowedKeyIds = allKeys.map(k => k.id);
-    }
-
-    // Fetch TSIG key from storage
-    const tsigKey = await tsigKeyService.getKeyForZone(zone, user.userId, allowedKeyIds);
-
-    if (!tsigKey) {
-      return res.status(403).json({
+    // Resolve the key by the explicitly requested keyId (request body), so a
+    // split-horizon zone is written to the exact view the user selected.
+    const resolved = await resolveZoneKey(user, zone, req.body.keyId);
+    if (!resolved.ok) {
+      return res.status(resolved.status).json({
         success: false,
-        code: ErrorCodes.MISSING_CONFIG,
-        error: 'No TSIG key found for this zone',
-        details: { zone }
+        code: resolved.code,
+        error: resolved.error,
+        details: resolved.details,
       });
     }
-
-    const keyConfig: ZoneConfig = {
-      server: tsigKey.server,
-      keyName: tsigKey.keyName,
-      keyValue: tsigKey.keyValue,
-      algorithm: tsigKey.algorithm,
-      id: tsigKey.id
-    };
+    const keyConfig = resolved.keyConfig;
 
     const result = await dnsService.addRecord(zone, record, keyConfig);
 
@@ -280,32 +328,18 @@ router.delete(
       });
     }
 
-    // For admins, get all key IDs; otherwise use the user's allowed keys
-    let allowedKeyIds = user.allowedKeyIds;
-    if (user.role === 'admin') {
-      const allKeys = await tsigKeyService.listKeys();
-      allowedKeyIds = allKeys.map(k => k.id);
-    }
-
-    // Fetch TSIG key from storage
-    const tsigKey = await tsigKeyService.getKeyForZone(zone, user.userId, allowedKeyIds);
-
-    if (!tsigKey) {
-      return res.status(403).json({
+    // Resolve the key by the explicitly requested keyId (request body), so a
+    // split-horizon zone is written to the exact view the user selected.
+    const resolved = await resolveZoneKey(user, zone, req.body.keyId);
+    if (!resolved.ok) {
+      return res.status(resolved.status).json({
         success: false,
-        code: ErrorCodes.MISSING_CONFIG,
-        error: 'No TSIG key found for this zone',
-        details: { zone }
+        code: resolved.code,
+        error: resolved.error,
+        details: resolved.details,
       });
     }
-
-    const keyConfig: ZoneConfig = {
-      server: tsigKey.server,
-      keyName: tsigKey.keyName,
-      keyValue: tsigKey.keyValue,
-      algorithm: tsigKey.algorithm,
-      id: tsigKey.id
-    };
+    const keyConfig = resolved.keyConfig;
 
     const result = await dnsService.deleteRecord(zone, record, keyConfig);
 
@@ -409,32 +443,18 @@ router.patch(
       });
     }
 
-    // For admins, get all key IDs; otherwise use the user's allowed keys
-    let allowedKeyIds = user.allowedKeyIds;
-    if (user.role === 'admin') {
-      const allKeys = await tsigKeyService.listKeys();
-      allowedKeyIds = allKeys.map(k => k.id);
-    }
-
-    // Fetch TSIG key from storage
-    const tsigKey = await tsigKeyService.getKeyForZone(zone, user.userId, allowedKeyIds);
-
-    if (!tsigKey) {
-      return res.status(403).json({
+    // Resolve the key by the explicitly requested keyId (request body), so a
+    // split-horizon zone is written to the exact view the user selected.
+    const resolved = await resolveZoneKey(user, zone, req.body.keyId);
+    if (!resolved.ok) {
+      return res.status(resolved.status).json({
         success: false,
-        code: ErrorCodes.MISSING_CONFIG,
-        error: 'No TSIG key found for this zone',
-        details: { zone }
+        code: resolved.code,
+        error: resolved.error,
+        details: resolved.details,
       });
     }
-
-    const keyConfig: ZoneConfig = {
-      server: tsigKey.server,
-      keyName: tsigKey.keyName,
-      keyValue: tsigKey.keyValue,
-      algorithm: tsigKey.algorithm,
-      id: tsigKey.id
-    };
+    const keyConfig = resolved.keyConfig;
 
     // Use atomic update operation
     const result = await dnsService.updateRecord(zone, oldRecord, newRecord, keyConfig);
@@ -547,30 +567,19 @@ router.post(
       }
     }
 
-    // For admins, get all key IDs; otherwise use the user's allowed keys
-    let allowedKeyIds = user.allowedKeyIds;
-    if (user.role === 'admin') {
-      const allKeys = await tsigKeyService.listKeys();
-      allowedKeyIds = allKeys.map(k => k.id);
-    }
-
-    const tsigKey = await tsigKeyService.getKeyForZone(zone, user.userId, allowedKeyIds);
-    if (!tsigKey) {
-      return res.status(403).json({
+    // Resolve the key by the explicitly requested keyId (request body). The
+    // apply flow groups pending changes by (zone, keyId) and sends one batch per
+    // group, so each split-horizon view is written through its own key.
+    const resolved = await resolveZoneKey(user, zone, req.body.keyId);
+    if (!resolved.ok) {
+      return res.status(resolved.status).json({
         success: false,
-        code: ErrorCodes.MISSING_CONFIG,
-        error: 'No TSIG key found for this zone',
-        details: { zone }
+        code: resolved.code,
+        error: resolved.error,
+        details: resolved.details,
       });
     }
-
-    const keyConfig: ZoneConfig = {
-      server: tsigKey.server,
-      keyName: tsigKey.keyName,
-      keyValue: tsigKey.keyValue,
-      algorithm: tsigKey.algorithm,
-      id: tsigKey.id
-    };
+    const keyConfig = resolved.keyConfig;
 
     const result = await dnsService.applyBatch(zone, changes, keyConfig);
 

--- a/backend/src/services/backupService.ts
+++ b/backend/src/services/backupService.ts
@@ -20,6 +20,9 @@ export interface DNSBackup {
   timestamp: number;
   zone: string;
   server: string;
+  // TSIG key/view this snapshot was taken through. Optional for backward
+  // compatibility with snapshots created before split-view support.
+  keyId?: string;
   records: DNSRecord[];
   type: 'auto' | 'manual';
   description?: string;
@@ -32,6 +35,7 @@ export interface BackupListItem {
   timestamp: number;
   zone: string;
   server: string;
+  keyId?: string;
   recordCount: number;
   type: 'auto' | 'manual';
   description?: string;
@@ -91,6 +95,7 @@ class BackupService {
           timestamp: b.timestamp,
           zone: b.zone,
           server: b.server,
+          keyId: b.keyId,
           recordCount: b.records.length,
           type: b.type,
           description: b.description,
@@ -147,6 +152,7 @@ class BackupService {
     userId: string,
     options: {
       server: string;
+      keyId?: string;
       type: 'auto' | 'manual';
       description?: string;
     }
@@ -159,6 +165,7 @@ class BackupService {
         timestamp: Date.now(),
         zone,
         server: options.server,
+        keyId: options.keyId,
         records,
         type: options.type,
         description: options.description,
@@ -260,6 +267,7 @@ class BackupService {
           timestamp: b.timestamp,
           zone: b.zone,
           server: b.server,
+          keyId: b.keyId,
           recordCount: b.records.length,
           type: b.type,
           description: b.description,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snap-dns",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/src/components/PendingChangesDrawer.tsx
+++ b/src/components/PendingChangesDrawer.tsx
@@ -129,14 +129,23 @@ function PendingChangesDrawer({
     setPendingChanges(items);
   };
 
-  // Group changes by zone; used by both the confirmation dialog and apply
-  const changesByZone = pendingChanges.reduce((acc: Record<string, PendingChange[]>, change) => {
-    if (!acc[change.zone]) {
-      acc[change.zone] = [];
+  // Group changes by (zone, keyId); used by both the confirmation dialog and
+  // apply. A split-horizon zone shares its name across keys/views, so each
+  // (zone, key) pair is its own atomic transaction and must be applied through
+  // the exact key it was queued under — never collapsed by zone name alone.
+  const changeGroups: { zone: string; keyId: string; changes: PendingChange[] }[] = (() => {
+    const map = new Map<string, { zone: string; keyId: string; changes: PendingChange[] }>();
+    for (const change of pendingChanges) {
+      const groupKey = `${change.zone} ${change.keyId}`;
+      let group = map.get(groupKey);
+      if (!group) {
+        group = { zone: change.zone, keyId: change.keyId, changes: [] };
+        map.set(groupKey, group);
+      }
+      group.changes.push(change);
     }
-    acc[change.zone].push(change);
-    return acc;
-  }, {});
+    return Array.from(map.values());
+  })();
 
   const handleApplyChanges = async () => {
     setConfirmOpen(false);
@@ -151,18 +160,20 @@ function PendingChangesDrawer({
     const failures: ZoneApplyFailure[] = [];
     const allWarnings: string[] = [];
 
-    for (const [zone, changes] of Object.entries(changesByZone) as [string, PendingChange[]][]) {
+    for (const { zone, keyId, changes } of changeGroups) {
       try {
-        // Create automatic snapshot before applying changes
+        // Create automatic snapshot before applying changes. Read and snapshot
+        // through the SAME key the changes will be applied with, so the backup
+        // reflects the correct split-horizon view.
         try {
-          const currentRecords = await dnsService.fetchZoneRecords(zone);
-          const firstChange = changes[0];
-          const keyConfig = backendKeys.find(k => k.id === firstChange.keyId);
+          const currentRecords = await dnsService.fetchZoneRecords(zone, keyId);
+          const keyConfig = (backendKeys || []).find(k => k.id === keyId);
 
           await backupService.createBackup(zone, currentRecords, {
             type: 'auto',
             description: `Automatic snapshot before applying ${changes.length} change${changes.length !== 1 ? 's' : ''}`,
             server: keyConfig?.server || 'unknown',
+            keyId,
             config: config as any
           });
         } catch (backupError) {
@@ -187,7 +198,7 @@ function PendingChangesDrawer({
           }
         });
 
-        const batchResult = await dnsService.applyBatch(zone, batchChanges);
+        const batchResult = await dnsService.applyBatch(zone, batchChanges, keyId);
         if (batchResult?.warnings?.length) allWarnings.push(...batchResult.warnings);
         appliedChanges.push(...changes);
         appliedZones.push(zone);
@@ -543,13 +554,18 @@ function PendingChangesDrawer({
         <DialogTitle>Apply changes to live DNS?</DialogTitle>
         <DialogContent>
           <DialogContentText component="div">
-            {Object.entries(changesByZone).map(([zone, changes]) => (
-              <Typography variant="body2" key={zone}>
-                {zone}: {changes.length} change{changes.length !== 1 ? 's' : ''}
-              </Typography>
-            ))}
+            {changeGroups.map(({ zone, keyId, changes }) => {
+              const key = (backendKeys || []).find(k => k.id === keyId);
+              // Name the key/view so a split-horizon zone reads unambiguously.
+              const keyLabel = key ? `${key.name} (${key.server})` : 'unknown key';
+              return (
+                <Typography variant="body2" key={`${zone} ${keyId}`}>
+                  {zone} — {keyLabel}: {changes.length} change{changes.length !== 1 ? 's' : ''}
+                </Typography>
+              );
+            })}
             <Typography variant="body2" sx={{ mt: 1 }} color="text.secondary">
-              An automatic snapshot of each zone is taken before applying.
+              An automatic snapshot of each zone is taken (per key/view) before applying.
             </Typography>
           </DialogContentText>
         </DialogContent>

--- a/src/components/Snapshots.tsx
+++ b/src/components/Snapshots.tsx
@@ -494,6 +494,20 @@ function Snapshots() {
     return backendKeys.filter(key => key.zones?.includes(selectedZone)) || [];
   }, [backendKeys, selectedZone]);
 
+  // Resolve which key/view a backup belongs to, so compare/restore read and
+  // write the SAME split-horizon view the snapshot was taken from. Prefer the
+  // key the snapshot recorded; for older snapshots (no keyId) fall back to a
+  // key on the same server serving the zone, then any key serving the zone.
+  const resolveBackupKeyId = useCallback(
+    (backup: { zone: string; keyId?: string; server?: string }): string | null => {
+      if (backup.keyId && backendKeys.some(k => k.id === backup.keyId)) return backup.keyId;
+      const serving = backendKeys.filter(k => k.zones?.includes(backup.zone));
+      const sameServer = backup.server ? serving.find(k => k.server === backup.server) : undefined;
+      return (sameServer || serving[0])?.id ?? null;
+    },
+    [backendKeys]
+  );
+
   // Auto-select the DNS key that serves the chosen zone in the Create Snapshot
   // panel, mirroring the Zone Editor sidebar: keep the current key if it still
   // serves the zone, otherwise pick the first key whose `zones` include it. This
@@ -543,12 +557,13 @@ function Snapshots() {
         throw new Error('No key configuration found');
       }
 
-      const records = await dnsService.fetchZoneRecords(selectedZone);
+      const records = await dnsService.fetchZoneRecords(selectedZone, keyConfig.id);
 
       const backup = await backupService.createBackup(selectedZone, records, {
         type: 'manual',
         description: 'Manual snapshot',
         server: keyConfig.server,
+        keyId: keyConfig.id,
         config: config as any
       });
 
@@ -695,7 +710,11 @@ function Snapshots() {
       const fullBackup = await backupService.getBackup(backupListItem.zone, backupListItem.id);
       setSelectedBackup(fullBackup);
 
-      const currentRecords = await dnsService.fetchZoneRecords(backupListItem.zone);
+      const keyId = resolveBackupKeyId(fullBackup);
+      if (!keyId) {
+        throw new Error('No key found for this zone');
+      }
+      const currentRecords = await dnsService.fetchZoneRecords(backupListItem.zone, keyId);
 
       if (!Array.isArray(currentRecords) || currentRecords.length === 0) {
         throw new Error('Failed to fetch current zone records or zone is empty');
@@ -859,13 +878,15 @@ function Snapshots() {
   // selected subset.
   const confirmRestore = async (recordsToRestore: DNSRecord[], isFullRestore = false) => {
     try {
-      const keyForZone = backendKeys.find(k => k.zones?.includes(selectedBackup.zone));
+      // Restore through the key/view the snapshot was taken from, so the queued
+      // changes carry the correct keyId and the apply flow targets that view.
+      const keyId = resolveBackupKeyId(selectedBackup);
 
-      if (!keyForZone) {
+      if (!keyId) {
         throw new Error('No key found for this zone');
       }
 
-      const currentRecords = await dnsService.fetchZoneRecords(selectedBackup.zone);
+      const currentRecords = await dnsService.fetchZoneRecords(selectedBackup.zone, keyId);
 
       const changes = computeRestoreChanges(
         currentRecords,
@@ -874,7 +895,7 @@ function Snapshots() {
         isFullRestore,
         {
           zone: selectedBackup.zone,
-          keyId: keyForZone.id,
+          keyId,
           source: {
             type: 'backup',
             id: selectedBackup.id,

--- a/src/components/ZoneEditor.tsx
+++ b/src/components/ZoneEditor.tsx
@@ -272,7 +272,7 @@ function ZoneEditor() {
     setError(null);
 
     try {
-      const records = await dnsService.fetchZoneRecords(selectedZone);
+      const records = await dnsService.fetchZoneRecords(selectedZone, selectedKey.id);
       setRecords(records);
     } catch (err) {
       console.error('Failed to load zone records:', err);

--- a/src/components/__tests__/PendingChangesDrawer.test.tsx
+++ b/src/components/__tests__/PendingChangesDrawer.test.tsx
@@ -44,10 +44,10 @@ jest.mock('../../context/ConfigContext', () => ({
 
 const applyBatch = dnsService.applyBatch as jest.Mock;
 
-const addChange = (zone: string, value: string): NewPendingChange => ({
+const addChange = (zone: string, value: string, keyId = 'key-1'): NewPendingChange => ({
   type: 'ADD',
   zone,
-  keyId: 'key-1',
+  keyId,
   record: { name: 'www', type: 'A', value, ttl: 300 } as any
 });
 
@@ -121,6 +121,26 @@ describe('PendingChangesDrawer apply flow', () => {
       expect.objectContaining({ zones: ['alpha.test', 'beta.test'] })
     );
     expect(screen.getByText('Pending Changes (0)')).toBeInTheDocument();
+  });
+
+  it('applies split-horizon changes (same zone, two keys) as separate batches per key', async () => {
+    // The reported bug: a zone name existing under an internal and an external
+    // key must NOT be collapsed. Each (zone, key) pair is its own batch, sent
+    // with its own keyId, so an internal edit can never hit the external view.
+    applyBatch.mockResolvedValue({});
+    renderDrawer([
+      addChange('split.test', '192.0.2.1', 'key-internal'),
+      addChange('split.test', '192.0.2.2', 'key-external'),
+    ]);
+
+    await startApply();
+
+    await waitFor(() => expect(applyBatch).toHaveBeenCalledTimes(2));
+    const calls = applyBatch.mock.calls;
+    // Each call: (zone, changes, keyId). Same zone name, distinct keys.
+    const keyIdsUsed = calls.map((c: any[]) => c[2]).sort();
+    expect(keyIdsUsed).toEqual(['key-external', 'key-internal']);
+    calls.forEach((c: any[]) => expect(c[0]).toBe('split.test'));
   });
 
   it('keeps only the failed zone pending on partial failure', async () => {

--- a/src/services/__tests__/dnsService.applyBatch.test.ts
+++ b/src/services/__tests__/dnsService.applyBatch.test.ts
@@ -24,13 +24,15 @@ describe('dnsService.applyBatch (frontend client)', () => {
       },
     ];
 
-    const result = await dnsService.applyBatch('example.com', changes);
+    const result = await dnsService.applyBatch('example.com', changes, 'key-123');
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, opts] = fetchMock.mock.calls[0];
     expect(url).toContain('/api/zones/example.com/records/batch');
     expect(opts.method).toBe('POST');
     const body = JSON.parse(opts.body);
+    // The selected key/view must accompany the batch so the backend targets it.
+    expect(body.keyId).toBe('key-123');
     expect(body.changes).toHaveLength(3);
     expect(body.changes[0].op).toBe('add');
     expect(body.changes[2].op).toBe('update');
@@ -39,7 +41,15 @@ describe('dnsService.applyBatch (frontend client)', () => {
   });
 
   it('rejects an empty change set without calling the API', async () => {
-    await expect(dnsService.applyBatch('example.com', [])).rejects.toThrow();
+    await expect(dnsService.applyBatch('example.com', [], 'key-123')).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a batch with no keyId without calling the API', async () => {
+    const changes: BatchChange[] = [
+      { op: 'add', record: { name: 'a', type: 'A', value: '1.1.1.1', ttl: 300 } as DNSRecord },
+    ];
+    await expect(dnsService.applyBatch('example.com', changes, '')).rejects.toThrow();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/services/backupService.ts
+++ b/src/services/backupService.ts
@@ -11,6 +11,9 @@ interface DNSBackup {
   timestamp: number;
   zone: string;
   server: string;
+  // The TSIG key/view this snapshot was taken through. Optional for backward
+  // compatibility with snapshots created before split-view support.
+  keyId?: string;
   records: DNSRecord[];
   type: 'auto' | 'manual';
   description?: string;
@@ -23,6 +26,7 @@ interface BackupListItem {
   timestamp: number;
   zone: string;
   server: string;
+  keyId?: string;
   recordCount: number;
   type: 'auto' | 'manual';
   description?: string;
@@ -34,6 +38,7 @@ interface BackupOptions {
   type: 'auto' | 'manual';
   description?: string;
   server?: string;
+  keyId?: string;
   config: Config;
 }
 
@@ -118,6 +123,7 @@ export class BackupService {
         body: JSON.stringify({
           records,
           server: options.server || options.config.defaultServer,
+          keyId: options.keyId,
           type: options.type,
           description: options.description,
         }),

--- a/src/services/dnsService.ts
+++ b/src/services/dnsService.ts
@@ -118,18 +118,26 @@ class DNSService {
     };
   }
 
-  async fetchZoneRecords(zone: string): Promise<DNSRecord[]> {
+  async fetchZoneRecords(zone: string, keyId: string): Promise<DNSRecord[]> {
     try {
       if (!zone) {
         throw new Error('Zone name is required');
       }
+      if (!keyId) {
+        // keyId identifies which TSIG key/view to read. Split-horizon zones
+        // share a name across views, so this must be explicit.
+        throw new Error('A key must be selected to read this zone');
+      }
 
       const headers = this.createHeaders();
-      const response = await fetch(`${this.baseUrl}/api/zones/${encodeURIComponent(zone)}`, {
-        method: 'GET',
-        headers,
-        credentials: 'include' // Send authentication cookies
-      });
+      const response = await fetch(
+        `${this.baseUrl}/api/zones/${encodeURIComponent(zone)}?keyId=${encodeURIComponent(keyId)}`,
+        {
+          method: 'GET',
+          headers,
+          credentials: 'include' // Send authentication cookies
+        }
+      );
 
       if (!response.ok) {
         const error = await response.json();
@@ -144,16 +152,20 @@ class DNSService {
     }
   }
 
-  async addRecord(zone: string, record: DNSRecord): Promise<{ warnings?: string[] }> {
+  async addRecord(zone: string, record: DNSRecord, keyId: string): Promise<{ warnings?: string[] }> {
     try {
       if (!zone || !record) {
         throw new Error('Zone and record are required');
+      }
+      if (!keyId) {
+        throw new Error('A key must be selected to modify this zone');
       }
 
       const headers = this.createHeaders();
       const preparedRecord = this.prepareRecordForRequest(record);
 
       const requestBody = {
+        keyId,
         record: preparedRecord
       };
 
@@ -187,16 +199,20 @@ class DNSService {
     }
   }
 
-  async deleteRecord(zone: string, record: DNSRecord): Promise<{ warnings?: string[] }> {
+  async deleteRecord(zone: string, record: DNSRecord, keyId: string): Promise<{ warnings?: string[] }> {
     try {
       if (!zone || !record) {
         throw new Error('Zone and record are required');
+      }
+      if (!keyId) {
+        throw new Error('A key must be selected to modify this zone');
       }
 
       const headers = this.createHeaders();
       const preparedRecord = this.prepareRecordForRequest(record);
 
       const requestBody = {
+        keyId,
         record: preparedRecord
       };
 
@@ -233,11 +249,15 @@ class DNSService {
   async updateRecord(
     zone: string,
     oldRecord: DNSRecord,
-    newRecord: DNSRecord
+    newRecord: DNSRecord,
+    keyId: string
   ): Promise<{ warnings?: string[] }> {
     try {
       if (!zone || !oldRecord || !newRecord) {
         throw new Error('Zone, old record, and new record are required');
+      }
+      if (!keyId) {
+        throw new Error('A key must be selected to modify this zone');
       }
 
       const headers = this.createHeaders();
@@ -245,6 +265,7 @@ class DNSService {
       const preparedNewRecord = this.prepareRecordForRequest(newRecord);
 
       const requestBody = {
+        keyId,
         oldRecord: preparedOldRecord,
         newRecord: preparedNewRecord
       };
@@ -284,10 +305,13 @@ class DNSService {
    * Apply a set of changes to one zone atomically (single backend transaction).
    * Each record is formatted the same way the single-record calls format it.
    */
-  async applyBatch(zone: string, changes: BatchChange[]): Promise<{ warnings?: string[] }> {
+  async applyBatch(zone: string, changes: BatchChange[], keyId: string): Promise<{ warnings?: string[] }> {
     try {
       if (!zone || !changes || changes.length === 0) {
         throw new Error('Zone and at least one change are required');
+      }
+      if (!keyId) {
+        throw new Error('A key must be selected to apply changes to this zone');
       }
 
       const prepared = changes.map((c) =>
@@ -304,7 +328,7 @@ class DNSService {
         method: 'POST',
         headers: this.createHeaders(),
         credentials: 'include',
-        body: JSON.stringify({ changes: prepared }),
+        body: JSON.stringify({ keyId, changes: prepared }),
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## The bug

A user updated the TTL for two A records in a zone's **internal** view and the change also affected the **external** view. Root cause: **snap-dns had no concept of a split-horizon view** and addressed a zone by name alone.

- The frontend (`src/services/dnsService.ts`) sent **only the zone name** — no key identifier — on every read/write.
- Every backend zone route resolved a TSIG key via `tsigKeyService.getKeyForZone(zone, …)`, which returns the **first** key whose `zones` list includes that name (`backend/src/services/tsigKeyService.ts`).

So when the same zone name exists under two keys (internal server + external server), the user's key selection was silently discarded and every operation went to whichever key sorted first. An internal-view edit could land on the external server.

## The fix — make the target view explicit end-to-end

**Backend**
- All `/api/zones` routes now **require a `keyId`** (`GET` query param; request body for add/delete/update/batch) and resolve the key by id through a new `resolveZoneKey` helper. It authorizes the key (must be in the caller's allowlist — admins get all) and verifies the key actually serves the zone, then targets that key's server. Missing/unauthorized/wrong-zone keys are rejected before any DNS work.
- `keyId` added to the Zod write schemas so it survives Zod's unknown-key stripping.

**Frontend**
- `dnsService` methods take and send `keyId` (GET query, write body).
- **Apply flow** (`PendingChangesDrawer`): pending changes are grouped by **(zone, keyId)** and applied as one atomic batch per group through its own key — changes across different keys are never collapsed. The confirmation dialog names the key/view per group.
- **Snapshots**: record the `keyId` a snapshot was taken through and use it for compare/restore (older snapshots without one fall back to a key on the same server, then any key serving the zone).

## Contract change

Zone API operations now require an explicit `keyId`. The frontend sends it automatically; any programmatic API client must include it. Documented in the CHANGELOG under 3.2.0.

## Tests
- New backend split-view integration suite: explicit-key dispatch to the correct server, missing keyId rejected, key-not-allowed → 403, key-not-serving-zone rejected, GET + batch.
- New frontend test: two keys on one zone name apply as **separate per-key batches**.
- Existing rbac/allowlist integration tests updated to the keyId contract.
- Backend 328/328 + build clean; frontend 242/242 + `tsc --noEmit` + production build clean.

Releases **3.2.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)