### PR TITLE
Fix TSIG keys appearing wiped after a burst of key edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - 2026-07-21
+
+### Fixed
+
+- **A burst of key edits no longer makes TSIG keys look wiped.** The strict
+  key-management rate limiter was applied to the whole `/api/tsig-keys` router,
+  so rapid edits also throttled `GET /api/tsig-keys`; the failed list fetch then
+  rendered as "No TSIG keys configured" — indistinguishable from the keys being
+  deleted. The limiter now applies only to mutating routes (create/update/delete);
+  reads use the general limiter, and the per-window mutation cap was raised from
+  10 to 30 for legitimate multi-key setup. Keys were never actually lost.
+- **The Keys panel now distinguishes a failed load from an empty list.** When the
+  list fetch errors (e.g. a 429), the table shows a "Couldn't load — they have not
+  been changed" state and a reassuring message instead of the empty "No TSIG keys
+  configured" state.
+
+### Changed
+
+- Rate limiters in `rateLimiter.ts` now evaluate the `RATE_LIMIT_ENABLED` toggle
+  per request (matching `loginLimiter`) instead of caching it at module load, so
+  the setting takes effect without a restart.
+
 ## [3.3.0] - 2026-07-21
 
 ### Added

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "main": "dist/server.js",
   "scripts": {
     "start": "node dist/server.js",

--- a/backend/src/__tests__/integration/keyRateLimit.integration.test.ts
+++ b/backend/src/__tests__/integration/keyRateLimit.integration.test.ts
@@ -1,0 +1,63 @@
+// backend/src/__tests__/integration/keyRateLimit.integration.test.ts
+// The strict key-management limiter must throttle MUTATIONS only, never reads.
+// Previously it was applied to the whole /api/tsig-keys router, so a burst of
+// edits also 429'd GET /api/tsig-keys — which the UI rendered as
+// "No TSIG keys configured", indistinguishable from the keys being wiped.
+//
+// Rate limiting is disabled by default in the suite (jest.setup.js); it is
+// flipped ON here per file. This relies on each limiter's skip() re-evaluating
+// the toggle per request (matching loginLimiter).
+import request from 'supertest';
+import type { Express } from 'express';
+import { buildTestApp, seedUser, loginAgent } from './testApp';
+import { UserRole } from '../../types/auth';
+
+const keyBody = {
+  name: 'rl-key',
+  server: '192.0.2.53',
+  keyName: 'rl-key.',
+  keyValue: 'c25hcC1kbnMtdGVzdC1rZXk=',
+  algorithm: 'hmac-sha256',
+  zones: ['example.com'],
+};
+
+describe('TSIG key management rate limiting (HTTP)', () => {
+  let app: Express;
+  const original = process.env.RATE_LIMIT_ENABLED;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = 'true';
+    app = buildTestApp();
+    // Distinct principals so each test gets its own limiter bucket.
+    await seedUser({ username: 'rlreader', password: 'reader-pass-123', role: UserRole.ADMIN });
+    await seedUser({ username: 'rlwriter', password: 'writer-pass-123', role: UserRole.ADMIN });
+  });
+
+  afterAll(() => {
+    process.env.RATE_LIMIT_ENABLED = original;
+  });
+
+  it('does not throttle reads (list) with the strict key-mutation limiter', async () => {
+    const { agent } = await loginAgent(app, 'rlreader', 'reader-pass-123');
+    // Fire more reads than the mutation cap (30). If reads shared that bucket
+    // the 31st would 429; they must all succeed (reads use the general limiter).
+    const statuses: number[] = [];
+    for (let i = 0; i < 35; i++) {
+      const res = await agent.get('/api/tsig-keys');
+      statuses.push(res.status);
+    }
+    expect(statuses.every((s) => s === 200)).toBe(true);
+  });
+
+  it('still throttles key mutations once the cap (30) is exceeded (429)', async () => {
+    const { agent } = await loginAgent(app, 'rlwriter', 'writer-pass-123');
+    const statuses: number[] = [];
+    for (let i = 0; i < 32; i++) {
+      const res = await agent.post('/api/tsig-keys').send({ ...keyBody, name: `rl-${i}` });
+      statuses.push(res.status);
+    }
+    // At most 30 creations succeed; a later mutation is blocked with 429.
+    expect(statuses.filter((s) => s === 201).length).toBeLessThanOrEqual(30);
+    expect(statuses).toContain(429);
+  });
+});

--- a/backend/src/middleware/rateLimiter.ts
+++ b/backend/src/middleware/rateLimiter.ts
@@ -8,8 +8,9 @@ import { isRateLimitEnabled } from '../config/securityToggles';
 
 // Rate limiting is ON by default (secure) and only skipped when explicitly
 // disabled via RATE_LIMIT_ENABLED=false -- not based on NODE_ENV. See
-// config/securityToggles.ts for the rationale.
-const rateLimitDisabled = !isRateLimitEnabled();
+// config/securityToggles.ts for the rationale. The toggle is evaluated PER
+// REQUEST (in each limiter's skip below), matching loginLimiter, so a runtime
+// change takes effect without a restart and tests can flip it per file.
 
 /**
  * Per-principal rate-limit key. Limiters run BEFORE requireAuth, so this inspects
@@ -45,9 +46,7 @@ export const dnsQueryLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   // Skip only when rate limiting is explicitly disabled (default: enabled)
-  skip: (_req) => {
-    return rateLimitDisabled;
-  },
+  skip: () => !isRateLimitEnabled(),
   keyGenerator: principalKey
 });
 
@@ -66,19 +65,19 @@ export const dnsModifyLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   // Skip only when rate limiting is explicitly disabled (default: enabled)
-  skip: (_req) => {
-    return rateLimitDisabled;
-  },
+  skip: () => !isRateLimitEnabled(),
   keyGenerator: principalKey
 });
 
 /**
- * Rate limiter for TSIG key operations
- * Very strict since key management is highly sensitive
+ * Rate limiter for TSIG key MUTATIONS (create/update/delete).
+ * Strict since key management is sensitive, but only applied to mutating routes
+ * — read/list stays on the general limiter so a burst of edits can never lock a
+ * user out of even viewing their keys (which previously looked like data loss).
  */
 export const keyManagementLimiter = rateLimit({
   windowMs: 5 * 60 * 1000, // 5 minutes
-  max: 10, // 10 key operations per 5 minutes
+  max: 30, // 30 key mutations per 5 minutes (headroom for setting up several keys)
   message: {
     success: false,
     error: 'Too many key management operations, please slow down',
@@ -87,9 +86,7 @@ export const keyManagementLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   // Skip only when rate limiting is explicitly disabled (default: enabled)
-  skip: (_req) => {
-    return rateLimitDisabled;
-  },
+  skip: () => !isRateLimitEnabled(),
   keyGenerator: principalKey
 });
 
@@ -108,9 +105,7 @@ export const tokenLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   // Skip only when rate limiting is explicitly disabled (default: enabled)
-  skip: (_req) => {
-    return rateLimitDisabled;
-  },
+  skip: () => !isRateLimitEnabled(),
   keyGenerator: principalKey
 });
 
@@ -129,9 +124,7 @@ export const webhookLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   // Skip only when rate limiting is explicitly disabled (default: enabled)
-  skip: (_req) => {
-    return rateLimitDisabled;
-  },
+  skip: () => !isRateLimitEnabled(),
   keyGenerator: principalKey
 });
 
@@ -150,8 +143,6 @@ export const generalApiLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   // Skip only when rate limiting is explicitly disabled (default: enabled)
-  skip: (_req) => {
-    return rateLimitDisabled;
-  },
+  skip: () => !isRateLimitEnabled(),
   keyGenerator: principalKey
 });

--- a/backend/src/routes/tsigKeyRoutes.ts
+++ b/backend/src/routes/tsigKeyRoutes.ts
@@ -9,8 +9,11 @@ import { auditService, AuditEventType } from '../services/auditService';
 
 const router = Router();
 
-// Apply rate limiting to all TSIG key routes
-router.use(keyManagementLimiter);
+// The strict key-management limiter is applied per-MUTATION-route below
+// (create/update/delete). GET/list is intentionally left on the app-level
+// general limiter: throttling reads with the strict mutation budget meant a
+// burst of edits also 429'd the list fetch, which the UI rendered as
+// "No TSIG keys configured" — indistinguishable from the keys being wiped.
 
 /**
  * GET /api/tsig-keys
@@ -43,7 +46,7 @@ router.get('/', requireAuth, async (req: Request, res: Response) => {
  * POST /api/tsig-keys
  * Create a new TSIG key (admin or editor only)
  */
-router.post('/', requireAuth, requirePasswordCurrent, requireWriteAccess, validateTSIGKeyCreate, async (req: Request, res: Response) => {
+router.post('/', keyManagementLimiter, requireAuth, requirePasswordCurrent, requireWriteAccess, validateTSIGKeyCreate, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthenticatedRequest;
     const user = authReq.user!;
@@ -134,7 +137,7 @@ router.get('/:keyId', requireAuth, async (req: Request, res: Response) => {
  * PUT /api/tsig-keys/:keyId
  * Update a TSIG key (admin or editor only)
  */
-router.put('/:keyId', requireAuth, requirePasswordCurrent, requireWriteAccess, validateTSIGKeyUpdate, async (req: Request, res: Response) => {
+router.put('/:keyId', keyManagementLimiter, requireAuth, requirePasswordCurrent, requireWriteAccess, validateTSIGKeyUpdate, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthenticatedRequest;
     const user = authReq.user!;
@@ -189,7 +192,7 @@ router.put('/:keyId', requireAuth, requirePasswordCurrent, requireWriteAccess, v
  * DELETE /api/tsig-keys/:keyId
  * Delete a TSIG key (admin only)
  */
-router.delete('/:keyId', requireAuth, requirePasswordCurrent, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
+router.delete('/:keyId', keyManagementLimiter, requireAuth, requirePasswordCurrent, requireRole(UserRole.ADMIN), async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthenticatedRequest;
     const user = authReq.user!;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snap-dns",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/src/components/TSIGKeyManagement.tsx
+++ b/src/components/TSIGKeyManagement.tsx
@@ -39,6 +39,10 @@ export default function TSIGKeyManagement() {
   const [keys, setKeys] = useState<TSIGKey[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  // Distinguishes "the list fetch failed" from "the list is genuinely empty".
+  // Without this, a failed/rate-limited load renders the empty-state row
+  // ("No TSIG keys configured"), which looks exactly like the keys were wiped.
+  const [loadError, setLoadError] = useState(false);
   const [formError, setFormError] = useState('');
   const [dialogOpen, setDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -66,8 +70,15 @@ export default function TSIGKeyManagement() {
       setError('');
       const data = await tsigKeyService.listKeys();
       setKeys(data);
+      setLoadError(false);
     } catch (err: any) {
-      setError(err.message || 'Failed to load TSIG keys');
+      // A failed load does NOT mean the keys are gone — they live server-side.
+      // Flag it so the table shows a "couldn't load" state, not the empty state.
+      setLoadError(true);
+      setError(
+        (err.message || 'Failed to load TSIG keys') +
+          ' — your keys have not been changed. If you were making rapid changes you may be briefly rate limited; try again shortly.'
+      );
     } finally {
       setLoading(false);
     }
@@ -242,7 +253,15 @@ export default function TSIGKeyManagement() {
             </TableRow>
           </TableHead>
           <TableBody>
-            {keys.length === 0 ? (
+            {keys.length === 0 && loadError ? (
+              <TableRow>
+                <TableCell colSpan={6} align="center">
+                  <Typography color="text.secondary" py={2}>
+                    Couldn't load TSIG keys. They have not been changed — retry shortly.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : keys.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={6} align="center">
                   <Typography color="text.secondary" py={2}>

--- a/src/components/__tests__/TSIGKeyManagement.test.tsx
+++ b/src/components/__tests__/TSIGKeyManagement.test.tsx
@@ -1,0 +1,47 @@
+// src/components/__tests__/TSIGKeyManagement.test.tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TSIGKeyManagement from '../TSIGKeyManagement';
+
+// The component talks to the backend only through this API client, mocked per test.
+const mockListKeys = jest.fn();
+jest.mock('../../services/tsigKeyService', () => ({
+  tsigKeyService: {
+    listKeys: (...args: unknown[]) => mockListKeys(...args),
+    createKey: jest.fn(),
+    updateKey: jest.fn(),
+    deleteKey: jest.fn(),
+  },
+}));
+
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1', username: 'admin', role: 'admin' } }),
+}));
+
+jest.mock('../../context/NotificationContext', () => ({
+  useNotification: () => ({ showSuccess: jest.fn(), showError: jest.fn(), showInfo: jest.fn() }),
+}));
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('TSIGKeyManagement — empty vs. load-error', () => {
+  it('shows the empty state when there are genuinely no keys', async () => {
+    mockListKeys.mockResolvedValue([]);
+    render(<TSIGKeyManagement />);
+
+    expect(await screen.findByText(/No TSIG keys configured/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Couldn.t load TSIG keys/i)).not.toBeInTheDocument();
+  });
+
+  it('shows a reassuring load-error state (never the "no keys" wipe-looking state) when the fetch fails', async () => {
+    // e.g. a 429 from the rate limiter, or any network/500 error.
+    mockListKeys.mockRejectedValue(new Error('Failed to fetch TSIG keys'));
+    render(<TSIGKeyManagement />);
+
+    // The "wiped"-looking empty state must NOT appear...
+    expect(await screen.findByText(/Couldn.t load TSIG keys/i)).toBeInTheDocument();
+    expect(screen.queryByText(/No TSIG keys configured/i)).not.toBeInTheDocument();
+    // ...and the surfaced error reassures the user their keys are intact.
+    expect(screen.getByText(/briefly rate limited/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Report
A user hit **"Too many key management operations, please slow down"** while adding domains to keys, then the Keys panel showed **"Failed to fetch TSIG keys"** and **"No TSIG keys configured"** — the keys appeared wiped. They also worried the key-edit form's blank secret field had been saved as an empty value.

## Findings
Two presentation/throttling bugs. **No key data was ever lost.**

1. **The strict limiter throttled reads.** `keyManagementLimiter` (10 ops / 5 min) was applied via `router.use()` to the *entire* `/api/tsig-keys` router, so a burst of edits also 429'd `GET /api/tsig-keys`.
2. **The UI conflated "fetch failed" with "empty."** A failed list fetch left `keys=[]`, and the table rendered the "No TSIG keys configured" empty state — identical to a real wipe.
3. **Not a bug (confirmed):** the edit form only sends `keyValue` when non-blank (`if (formData.keyValue)`), the backend only re-encrypts a truthy value (`if (updates.keyValue)`), and the field is labelled *"Leave blank to keep existing key value."* Editing a key to add zones never overwrites the stored secret.

## Fix
- **`rateLimiter.ts`** — apply `keyManagementLimiter` to mutating routes only (POST/PUT/DELETE); reads stay on the general limiter. Raise the mutation cap **10 → 30** for legitimate multi-key setup. Evaluate `RATE_LIMIT_ENABLED` **per request** (matching `loginLimiter`) instead of caching at module load, so the toggle is honored at runtime and testable.
- **`tsigKeyRoutes.ts`** — limiter moved off `router.use()` onto the three mutation routes.
- **`TSIGKeyManagement.tsx`** — track a `loadError` flag; on a failed fetch show a *"Couldn't load — they have not been changed"* row plus a reassuring, rate-limit-aware alert, never the empty "no keys" state.

## Tests
- `keyRateLimit.integration.test.ts`: reads are **not** throttled past the mutation cap; mutations still return 429 (positive control that limiting is active).
- `TSIGKeyManagement.test.tsx`: load-error state vs. genuinely-empty state.
- Backend **362/362** + build clean; frontend **247/247** + `tsc --noEmit` clean.

Releases **3.3.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)