### PR TITLE
Fix webhook test/notifications failing with NOT_AUTHENTICATED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.2] - 2026-07-21
+
+### Fixed
+
+- **Webhook "Test" and change notifications no longer fail with "Authentication
+  required".** The frontend posts webhook notifications through the authenticated
+  backend proxy (`POST /api/webhook/notify`, behind `requireAuth`), but the
+  `fetch` in `notificationService.sendWebhook` omitted `credentials: 'include'`,
+  so the session cookie was never sent and the request returned 401
+  `NOT_AUTHENTICATED`. This affected both the "Test Webhook" button and real
+  post-change notifications (the latter failed silently). Sending the cookie
+  fixes both. The webhook delivery itself was never broken — only snap-dns's
+  authenticated proxy was rejecting the request.
+
 ## [3.3.1] - 2026-07-21
 
 ### Fixed

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "main": "dist/server.js",
   "scripts": {
     "start": "node dist/server.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snap-dns",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/src/services/__tests__/notificationService.test.ts
+++ b/src/services/__tests__/notificationService.test.ts
@@ -1,0 +1,32 @@
+// src/services/__tests__/notificationService.test.ts
+// The webhook proxy endpoint (/api/webhook/notify) is behind requireAuth, so the
+// browser MUST send the session cookie. Without credentials:'include' the request
+// is unauthenticated (401 NOT_AUTHENTICATED) and both the "Test Webhook" button
+// and real change notifications fail. Regression test for that.
+import { notificationService } from '../notificationService';
+
+describe('notificationService — backend webhook proxy auth', () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    (global as any).fetch = fetchMock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      clone: () => ({ text: async () => '' }),
+      json: async () => ({ success: true }),
+    });
+    notificationService.setWebhookConfig('https://example.com/hook', 'teams');
+  });
+
+  it('posts to /api/webhook/notify with the session cookie (credentials: include)', async () => {
+    await notificationService.testWebhook();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/webhook/notify');
+    expect(opts.method).toBe('POST');
+    // The crux: the request must carry the session cookie, or requireAuth 401s.
+    expect(opts.credentials).toBe('include');
+  });
+});

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -125,6 +125,10 @@ class NotificationService {
         headers: {
           'Content-Type': 'application/json',
         },
+        // Send the session cookie: /api/webhook/notify is behind requireAuth, so
+        // without this the request is unauthenticated (401 NOT_AUTHENTICATED) and
+        // both the "Test Webhook" button and real change notifications fail.
+        credentials: 'include',
         body: JSON.stringify({
           config,
           payload


### PR DESCRIPTION
## Report
Adding a Teams webhook and clicking **Test Webhook** failed:
```
Failed to send test notification: {"success":false,"error":"Authentication required","code":"NOT_AUTHENTICATED"}
```
The webhook itself was verified working from a standalone script.

## Root cause
The frontend sends webhook notifications through snap-dns's **authenticated** backend proxy — `POST /api/webhook/notify`, which is behind `requireAuth`. But the `fetch` in `notificationService.sendWebhook` **omitted `credentials: 'include'`**, so the browser never sent the session cookie and the backend returned `401 NOT_AUTHENTICATED`. Every other frontend service call (`dnsService`, `tsigKeyService`, `tokenService`, `backupService`) already includes `credentials: 'include'` — this one was the outlier.

This affected **both**:
- the "Test Webhook" button (surfaces the error), and
- real post-change notifications (`sendNotification` → `sendWebhook`), which were failing **silently** inside a warn-only `catch`.

The standalone script worked because it POSTs straight to Teams, bypassing snap-dns's proxy.

## Fix
Add `credentials: 'include'` to the `sendWebhook` fetch. CORS already permits credentialed cross-origin requests (login/keys/zones rely on it), so no backend change is needed.

## Tests
- `notificationService.test.ts`: asserts the proxy POST goes to `/api/webhook/notify` **with `credentials: 'include'`** (fails pre-fix, where it was `undefined`).
- Frontend **248/248** + `tsc --noEmit` + production build clean.

Releases **3.3.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)