### PR TITLE
Surface webhook notification failures after applying changes

### DIFF
--- a/src/components/PendingChangesDrawer.tsx
+++ b/src/components/PendingChangesDrawer.tsx
@@ -68,7 +68,7 @@ function PendingChangesDrawer({
     setShowPendingDrawer
   } = usePendingChanges();
   const { config } = useConfig();
-  const { showSuccess, showError } = useNotification();
+  const { showSuccess, showError, showWarning } = useNotification();
   const [applying, setApplying] = useState(false);
   const [applyFailures, setApplyFailures] = useState<ZoneApplyFailure[]>([]);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -229,7 +229,11 @@ function PendingChangesDrawer({
           totalChanges: appliedChanges.length
         });
       } catch (notifyError) {
+        // The DNS changes already succeeded; a failed webhook notification must
+        // not be reported as an apply failure. Surface it as a non-blocking
+        // warning so a broken notification path can't go unnoticed.
         console.warn('Failed to send notification:', notifyError);
+        showWarning(`Changes applied, but the webhook notification failed: ${(notifyError as Error).message}`);
       }
     }
 

--- a/src/components/__tests__/PendingChangesDrawer.test.tsx
+++ b/src/components/__tests__/PendingChangesDrawer.test.tsx
@@ -34,8 +34,13 @@ jest.mock('../../services/tsigKeyService', () => ({
 
 const mockShowSuccess = jest.fn();
 const mockShowError = jest.fn();
+const mockShowWarning = jest.fn();
 jest.mock('../../context/NotificationContext', () => ({
-  useNotification: () => ({ showSuccess: mockShowSuccess, showError: mockShowError })
+  useNotification: () => ({
+    showSuccess: mockShowSuccess,
+    showError: mockShowError,
+    showWarning: mockShowWarning
+  })
 }));
 
 jest.mock('../../context/ConfigContext', () => ({
@@ -177,6 +182,30 @@ describe('PendingChangesDrawer apply flow', () => {
       expect.objectContaining({ zones: ['alpha.test'] })
     );
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('still succeeds but warns the user when the webhook notification fails', async () => {
+    // A failed notification must NOT turn a successful apply into a failure:
+    // the changes are committed and cleared, success is reported, and a
+    // separate non-blocking warning surfaces the notification failure.
+    applyBatch.mockResolvedValue({});
+    (notificationService.sendNotification as jest.Mock).mockRejectedValueOnce(
+      new Error('webhook 401')
+    );
+    const onClose = jest.fn();
+    renderDrawer([addChange('alpha.test', '192.0.2.1')], onClose);
+
+    await startApply();
+
+    await waitFor(() => expect(mockShowSuccess).toHaveBeenCalled());
+    expect(mockShowSuccess).toHaveBeenCalledWith('Successfully applied 1 change to 1 zone');
+    expect(mockShowWarning).toHaveBeenCalledWith(
+      'Changes applied, but the webhook notification failed: webhook 401'
+    );
+    expect(mockShowError).not.toHaveBeenCalled();
+    // Apply still completed: queue cleared and drawer closed.
+    expect(screen.getByText('Pending Changes (0)')).toBeInTheDocument();
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
   it('leaves everything pending when every zone fails', async () => {


### PR DESCRIPTION
## Problem

When DNS changes are applied, `PendingChangesDrawer` calls `notificationService.sendNotification(...)` in a `catch` block that only did `console.warn`. If the webhook notification path is broken, the user never sees it — which is exactly how a recent auth bug in the webhook path went unnoticed.

## Change

`src/components/PendingChangesDrawer.tsx`: after a successful apply, if the notification send rejects, the app now shows a non-blocking warning toast via `useNotification().showWarning`:

> Changes applied, but the webhook notification failed: `<reason>`

The `console.warn` is kept for logs. A notification failure is NOT turned into an apply failure — the DNS changes still commit, the queue clears, and success is still reported. This is the only apply-time `sendNotification` call site; snapshot restore queues changes that flow through this same drawer.

## Tests

Added a `PendingChangesDrawer` test asserting that when `sendNotification` rejects, the apply still succeeds (success toast shown, queue cleared, drawer closed) AND a user-visible warning is shown, with no error toast.

- `npx tsc --noEmit` — clean
- `CI=true npx react-scripts test --watchAll=false` — 249 passed, 23 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)